### PR TITLE
Add media management abilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Each ability enforces a WordPress capability check. The table below maps standar
 | Role          | Plugin-relevant capabilities provided                                    | Suitable for                                                        |
 | ------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------- |
 | Subscriber    | `read`                                                                   | Read-only workflows: taxonomy browsing, health checks, SEO overview |
-| Author        | `edit_posts`, `delete_posts`                                             | Creating and managing the agent's own posts only                    |
+| Author        | `edit_posts`, `delete_posts`, `upload_files`                             | Creating and managing the agent's own posts and media               |
 | **Editor** ✓  | All Author caps + `edit_pages`, `delete_pages`, `manage_categories`, `moderate_comments` | **Full editorial control — recommended default** |
 | Administrator | All Editor caps, plus extra administrative capabilities not required by the current ability set | Future admin-only audit workflows, if added |
 
@@ -147,6 +147,14 @@ Each ability enforces a WordPress capability check. The table below maps standar
 | `wp-mcp/approve-comment` | Approve a comment                                 | `moderate_comments` | Editor    |
 | `wp-mcp/trash-comment`   | Move a comment to trash                           | `moderate_comments` | Editor    |
 | `wp-mcp/spam-comment`    | Mark a comment as spam                            | `moderate_comments` | Editor    |
+
+### Media
+| Ability                | Description                                             | Required Capability | Min. Role |
+| ---------------------- | ------------------------------------------------------- | ------------------- | --------- |
+| `wp-mcp/list-media`    | List media items with filters (MIME type, search, pagination) | `upload_files`      | Author    |
+| `wp-mcp/get-media`     | Get a single media item by ID                           | `upload_files`      | Author    |
+| `wp-mcp/update-media`  | Update media alt text, title, and caption               | `upload_files`      | Author    |
+| `wp-mcp/delete-media`  | Permanently delete a media item                         | `delete_posts`      | Author    |
 
 ### Site Health
 | Ability                    | Description                                                                                                | Required Capability | Min. Role  |
@@ -223,7 +231,7 @@ It is recommended to create a dedicated user for your AI agent rather than using
 3. Set the **Role** to **Editor**
 4. Click **Add New User**
 
-> **Why Editor and not Administrator?** The Editor role covers all capabilities used by the current ability set (`edit_posts`, `edit_pages`, `delete_posts`, `delete_pages`, `manage_categories`, `moderate_comments`, `read`). For planned audit abilities — database health, performance status, backup status, plugin audit, and user access audit — an Administrator account will be required, as those abilities need `manage_options`, `activate_plugins`, or `edit_users`. If you plan to use those abilities, create a separate Administrator service account and keep the Editor account for content workflows. See the [Role overview](#role-overview) for the full breakdown.
+> **Why Editor and not Administrator?** The Editor role covers all capabilities used by the current ability set (`edit_posts`, `edit_pages`, `delete_posts`, `delete_pages`, `upload_files`, `manage_categories`, `moderate_comments`, `read`). For planned audit abilities — database health, performance status, backup status, plugin audit, and user access audit — an Administrator account will be required, as those abilities need `manage_options`, `activate_plugins`, or `edit_users`. If you plan to use those abilities, create a separate Administrator service account and keep the Editor account for content workflows. See the [Role overview](#role-overview) for the full breakdown.
 
 ### 4. Create an application password
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ Each ability enforces a WordPress capability check. The table below maps standar
 | `wp-mcp/update-media`  | Update media alt text, title, and caption               | `upload_files`      | Author    |
 | `wp-mcp/delete-media`  | Permanently delete a media item                         | `delete_posts`      | Author    |
 
+† Author-role access is scoped to media owned by the authenticated user. Use **Editor** to manage media site-wide.
+
 ### Site Health
 | Ability                    | Description                                                                                                | Required Capability | Min. Role  |
 | -------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------- | ---------- |

--- a/includes/class-media.php
+++ b/includes/class-media.php
@@ -1,0 +1,226 @@
+<?php
+
+defined( 'ABSPATH' ) || exit;
+
+class WP_MCP_Media {
+
+	public static function register() {
+		self::register_list();
+		self::register_get();
+		self::register_update();
+		self::register_delete();
+	}
+
+	private static function normalize( $attachment ) {
+		$attachment = get_post( $attachment );
+		if ( ! $attachment || 'attachment' !== $attachment->post_type ) {
+			return null;
+		}
+
+		$metadata = wp_get_attachment_metadata( $attachment->ID );
+		$file     = get_attached_file( $attachment->ID );
+		$data     = [
+			'id'            => (int) $attachment->ID,
+			'title'         => $attachment->post_title,
+			'caption'       => $attachment->post_excerpt,
+			'alt_text'      => get_post_meta( $attachment->ID, '_wp_attachment_image_alt', true ),
+			'mime_type'     => $attachment->post_mime_type,
+			'url'           => wp_get_attachment_url( $attachment->ID ),
+			'filename'      => $file ? basename( $file ) : '',
+			'author'        => (int) $attachment->post_author,
+			'parent_id'     => (int) $attachment->post_parent,
+			'date_created'  => $attachment->post_date,
+			'date_modified' => $attachment->post_modified,
+		];
+
+		if ( is_array( $metadata ) ) {
+			if ( isset( $metadata['width'] ) ) {
+				$data['width'] = (int) $metadata['width'];
+			}
+			if ( isset( $metadata['height'] ) ) {
+				$data['height'] = (int) $metadata['height'];
+			}
+		}
+
+		return $data;
+	}
+
+	private static function permission( $cap ) {
+		return function () use ( $cap ) {
+			if ( ! current_user_can( $cap ) ) {
+				return new WP_Error( 'forbidden', "Requires {$cap} capability." );
+			}
+			return true;
+		};
+	}
+
+	private static function register_list() {
+		wp_register_ability( 'wp-mcp/list-media', [
+			'label'               => 'List Media',
+			'description'         => 'List WordPress media items with optional filters.',
+			'category'            => 'wp-mcp',
+			'input_schema'        => [
+				'type'       => 'object',
+				'properties' => [
+					'mime_type' => [ 'type' => 'string', 'description' => 'Filter by MIME type, such as image/jpeg or application/pdf' ],
+					'search'    => [ 'type' => 'string' ],
+					'per_page'  => [ 'type' => 'integer', 'minimum' => 1, 'maximum' => 100, 'default' => 20 ],
+					'page'      => [ 'type' => 'integer', 'minimum' => 1, 'default' => 1 ],
+				],
+			],
+			'execute_callback'    => function ( $input ) {
+				$args = [
+					'post_type'      => 'attachment',
+					'post_status'    => 'inherit',
+					'posts_per_page' => min( (int) ( $input['per_page'] ?? 20 ), 100 ),
+					'paged'          => max( 1, (int) ( $input['page'] ?? 1 ) ),
+					'orderby'        => 'date',
+					'order'          => 'DESC',
+				];
+
+				if ( ! empty( $input['mime_type'] ) ) {
+					$args['post_mime_type'] = sanitize_text_field( $input['mime_type'] );
+				}
+				if ( ! empty( $input['search'] ) ) {
+					$args['s'] = sanitize_text_field( $input['search'] );
+				}
+
+				$query = new WP_Query( $args );
+
+				return [
+					'success' => true,
+					'data'    => [
+						'items'       => array_values( array_filter( array_map( [ self::class, 'normalize' ], $query->posts ) ) ),
+						'total'       => (int) $query->found_posts,
+						'total_pages' => (int) $query->max_num_pages,
+					],
+				];
+			},
+			'permission_callback' => self::permission( 'upload_files' ),
+			'meta'                => [
+				'annotations' => [ 'readonly' => true, 'destructive' => false, 'idempotent' => true ],
+				'mcp'         => [ 'public' => true, 'type' => 'tool' ],
+			],
+		] );
+	}
+
+	private static function register_get() {
+		wp_register_ability( 'wp-mcp/get-media', [
+			'label'               => 'Get Media',
+			'description'         => 'Get a single WordPress media item by ID.',
+			'category'            => 'wp-mcp',
+			'input_schema'        => [
+				'type'       => 'object',
+				'properties' => [
+					'media_id' => [ 'type' => 'integer', 'description' => 'Media attachment ID' ],
+				],
+				'required'   => [ 'media_id' ],
+			],
+			'execute_callback'    => function ( $input ) {
+				$id         = absint( $input['media_id'] );
+				$attachment = get_post( $id );
+
+				if ( ! $attachment || 'attachment' !== $attachment->post_type ) {
+					return [ 'success' => false, 'error' => 'Media item not found.' ];
+				}
+
+				return [ 'success' => true, 'data' => self::normalize( $attachment ) ];
+			},
+			'permission_callback' => self::permission( 'upload_files' ),
+			'meta'                => [
+				'annotations' => [ 'readonly' => true, 'destructive' => false, 'idempotent' => true ],
+				'mcp'         => [ 'public' => true, 'type' => 'tool' ],
+			],
+		] );
+	}
+
+	private static function register_update() {
+		wp_register_ability( 'wp-mcp/update-media', [
+			'label'               => 'Update Media',
+			'description'         => 'Update media alt text, title, and caption.',
+			'category'            => 'wp-mcp',
+			'input_schema'        => [
+				'type'       => 'object',
+				'properties' => [
+					'media_id' => [ 'type' => 'integer', 'description' => 'Media attachment ID to update' ],
+					'alt_text' => [ 'type' => 'string' ],
+					'title'    => [ 'type' => 'string' ],
+					'caption'  => [ 'type' => 'string' ],
+				],
+				'required'   => [ 'media_id' ],
+			],
+			'execute_callback'    => function ( $input ) {
+				$id         = absint( $input['media_id'] );
+				$attachment = get_post( $id );
+
+				if ( ! $attachment || 'attachment' !== $attachment->post_type ) {
+					return [ 'success' => false, 'error' => 'Media item not found.' ];
+				}
+
+				$args = [ 'ID' => $id ];
+
+				if ( isset( $input['title'] ) ) {
+					$args['post_title'] = sanitize_text_field( $input['title'] );
+				}
+				if ( isset( $input['caption'] ) ) {
+					$args['post_excerpt'] = wp_kses_post( $input['caption'] );
+				}
+
+				if ( count( $args ) > 1 ) {
+					$result = wp_update_post( $args, true );
+
+					if ( is_wp_error( $result ) ) {
+						return [ 'success' => false, 'error' => $result->get_error_message() ];
+					}
+				}
+
+				if ( isset( $input['alt_text'] ) ) {
+					update_post_meta( $id, '_wp_attachment_image_alt', sanitize_text_field( $input['alt_text'] ) );
+				}
+
+				return [ 'success' => true, 'data' => self::normalize( $id ) ];
+			},
+			'permission_callback' => self::permission( 'upload_files' ),
+			'meta'                => [
+				'annotations' => [ 'readonly' => false, 'destructive' => false, 'idempotent' => false ],
+				'mcp'         => [ 'public' => true, 'type' => 'tool' ],
+			],
+		] );
+	}
+
+	private static function register_delete() {
+		wp_register_ability( 'wp-mcp/delete-media', [
+			'label'               => 'Delete Media',
+			'description'         => 'Permanently delete a WordPress media item by ID.',
+			'category'            => 'wp-mcp',
+			'input_schema'        => [
+				'type'       => 'object',
+				'properties' => [
+					'media_id' => [ 'type' => 'integer', 'description' => 'Media attachment ID to permanently delete' ],
+				],
+				'required'   => [ 'media_id' ],
+			],
+			'execute_callback'    => function ( $input ) {
+				$id         = absint( $input['media_id'] );
+				$attachment = get_post( $id );
+
+				if ( ! $attachment || 'attachment' !== $attachment->post_type ) {
+					return [ 'success' => false, 'error' => 'Media item not found.' ];
+				}
+
+				$result = wp_delete_attachment( $id, true );
+
+				if ( ! $result ) {
+					return [ 'success' => false, 'error' => 'Failed to delete media item.' ];
+				}
+
+				return [ 'success' => true, 'data' => [ 'id' => $id, 'deleted' => true ] ];
+			},
+			'permission_callback' => self::permission( 'delete_posts' ),
+			'meta'                => [
+				'annotations' => [ 'readonly' => false, 'destructive' => true, 'idempotent' => false ],
+				'mcp'         => [ 'public' => true, 'type' => 'tool' ],
+			],
+		] );
+	}
+}

--- a/includes/class-media.php
+++ b/includes/class-media.php
@@ -54,6 +54,32 @@ class WP_MCP_Media {
 		};
 	}
 
+	private static function user_can_view_attachment( $attachment ) {
+		$attachment = get_post( $attachment );
+		if ( ! $attachment || 'attachment' !== $attachment->post_type ) {
+			return false;
+		}
+
+		if ( current_user_can( 'edit_others_posts' ) ) {
+			return true;
+		}
+
+		return (int) $attachment->post_author === get_current_user_id();
+	}
+
+	private static function user_can_delete_attachment( $attachment ) {
+		$attachment = get_post( $attachment );
+		if ( ! $attachment || 'attachment' !== $attachment->post_type ) {
+			return false;
+		}
+
+		if ( current_user_can( 'delete_others_posts' ) ) {
+			return true;
+		}
+
+		return (int) $attachment->post_author === get_current_user_id();
+	}
+
 	private static function register_list() {
 		wp_register_ability( 'wp-mcp/list-media', [
 			'label'               => 'List Media',
@@ -83,6 +109,9 @@ class WP_MCP_Media {
 				}
 				if ( ! empty( $input['search'] ) ) {
 					$args['s'] = sanitize_text_field( $input['search'] );
+				}
+				if ( ! current_user_can( 'edit_others_posts' ) ) {
+					$args['author'] = get_current_user_id();
 				}
 
 				$query = new WP_Query( $args );
@@ -123,6 +152,9 @@ class WP_MCP_Media {
 				if ( ! $attachment || 'attachment' !== $attachment->post_type ) {
 					return [ 'success' => false, 'error' => 'Media item not found.' ];
 				}
+				if ( ! self::user_can_view_attachment( $attachment ) ) {
+					return [ 'success' => false, 'error' => 'You do not have permission to view this media item.' ];
+				}
 
 				return [ 'success' => true, 'data' => self::normalize( $attachment ) ];
 			},
@@ -155,6 +187,9 @@ class WP_MCP_Media {
 
 				if ( ! $attachment || 'attachment' !== $attachment->post_type ) {
 					return [ 'success' => false, 'error' => 'Media item not found.' ];
+				}
+				if ( ! self::user_can_view_attachment( $attachment ) ) {
+					return [ 'success' => false, 'error' => 'You do not have permission to update this media item.' ];
 				}
 
 				$args = [ 'ID' => $id ];
@@ -206,6 +241,9 @@ class WP_MCP_Media {
 
 				if ( ! $attachment || 'attachment' !== $attachment->post_type ) {
 					return [ 'success' => false, 'error' => 'Media item not found.' ];
+				}
+				if ( ! self::user_can_delete_attachment( $attachment ) ) {
+					return [ 'success' => false, 'error' => 'You do not have permission to delete this media item.' ];
 				}
 
 				$result = wp_delete_attachment( $id, true );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: mcp, ai, automation, content-management, artificial-intelligence
 Requires at least: 6.9
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 1.3.1
+Stable tag: 1.4.0
 License: GPL-2.0+
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -14,7 +14,7 @@ Adds content management abilities to the WordPress MCP Adapter, giving AI agents
 
 WordPress MCP Abilities is a companion plugin for the official [MCP Adapter](https://wordpress.org/plugins/mcp-adapter/) plugin. The MCP Adapter is a transport framework — it handles the MCP session, REST endpoint, and protocol routing — but ships with no content management abilities out of the box. Any tools an AI agent can actually call must come from plugins that register them. This plugin fills that gap, giving your AI agent the tools to take action: publish a draft, run a security audit, check site health, or analyze a post's SEO.
 
-WordPress MCP Abilities registers abilities across seven groups, giving AI agents (such as Claude) a full working vocabulary for your WordPress site:
+WordPress MCP Abilities registers abilities across eight groups, giving AI agents (such as Claude) a full working vocabulary for your WordPress site:
 
 **Posts**
 Create, read, update, and delete posts. Supports all statuses including scheduled (future) posts, category and tag assignment, and pagination.
@@ -27,6 +27,9 @@ List, create, and delete categories and tags. Category creation supports parent 
 
 **Comments**
 List comments with filters, approve, trash, or mark as spam — all through the standard WordPress comment moderation flow.
+
+**Media**
+List, inspect, update, and permanently delete media attachments. Supports MIME type and search filters, pagination, alt text updates, title updates, and caption updates.
 
 **Site Health**
 Run WordPress's built-in health tests and get results grouped by severity: critical, recommended, and good.
@@ -74,7 +77,7 @@ No, but behavior differs depending on whether it is active:
 
 = What WordPress user role should I use? =
 
-For the current ability set, use the **Editor** role. It covers all capabilities the plugin currently uses: `edit_posts`, `edit_pages`, `delete_posts`, `delete_pages`, `manage_categories`, `moderate_comments`, and `read`. Administrator is not needed for any of these and gives the AI agent unnecessary access to site settings, user management, and plugin installation.
+For the current ability set, use the **Editor** role. It covers all capabilities the plugin currently uses: `edit_posts`, `edit_pages`, `delete_posts`, `delete_pages`, `upload_files`, `manage_categories`, `moderate_comments`, and `read`. Administrator is not needed for any of these and gives the AI agent unnecessary access to site settings, user management, and plugin installation.
 
 Note on role scope: the `edit_posts` capability is available to Authors as well, but WordPress scopes query results to the authenticated user's own content unless `edit_others_posts` is also present (which Editors have). Use an Author-role account only if you intentionally want the agent limited to content it created. For full site-wide editorial control, use Editor.
 
@@ -88,7 +91,7 @@ After activation, call `mcp-adapter-discover-abilities` from your MCP client. Yo
 
 = Are write operations safe? =
 
-Delete operations for posts and pages move content to trash, not permanent deletion. All inputs are sanitized using WordPress core functions. All operations go through the WordPress API — no direct database queries.
+Delete operations for posts and pages move content to trash. Media delete permanently removes the attachment and its files. All inputs are sanitized using WordPress core functions. All operations go through the WordPress API — no direct database queries.
 
 == Screenshots ==
 
@@ -96,6 +99,10 @@ Delete operations for posts and pages move content to trash, not permanent delet
 2. After: all abilities available — full editorial access to posts, pages, taxonomy, comments, site health, security, and SEO.
 
 == Changelog ==
+
+= 1.4.0 =
+* Add media management abilities: `list-media`, `get-media`, `update-media`, and `delete-media`
+* 28 abilities: posts (5), pages (5), taxonomy (6), comments (4), media (4), site health (1), security audit (1), SEO analysis (2)
 
 = 1.3.1 =
 * Add `yoast_meta_description` and `yoast_focus_keyword` fields to `update-post` and `update-page`
@@ -108,6 +115,9 @@ Delete operations for posts and pages move content to trash, not permanent delet
 * Security audit with fail/warn/pass buckets and remediation guidance
 
 == Upgrade Notice ==
+
+= 1.4.0 =
+Adds media list, get, update, and permanent delete abilities.
 
 = 1.3.1 =
 Adds Yoast meta description and focus keyword fields to update-post and update-page.

--- a/readme.txt
+++ b/readme.txt
@@ -79,7 +79,7 @@ No, but behavior differs depending on whether it is active:
 
 For the current ability set, use the **Editor** role. It covers all capabilities the plugin currently uses: `edit_posts`, `edit_pages`, `delete_posts`, `delete_pages`, `upload_files`, `manage_categories`, `moderate_comments`, and `read`. Administrator is not needed for any of these and gives the AI agent unnecessary access to site settings, user management, and plugin installation.
 
-Note on role scope: the `edit_posts` capability is available to Authors as well, but WordPress scopes query results to the authenticated user's own content unless `edit_others_posts` is also present (which Editors have). Use an Author-role account only if you intentionally want the agent limited to content it created. For full site-wide editorial control, use Editor.
+Note on role scope: the `edit_posts` and `upload_files` capabilities are available to Authors as well, but WordPress scopes results and write access to the authenticated user's own content unless `edit_others_posts` / `delete_others_posts` are also present (which Editors have). Use an Author-role account only if you intentionally want the agent limited to content it created. For full site-wide editorial control, use Editor.
 
 Planned audit abilities — database health, performance status, backup detection, plugin audit, and user access audit — will require an **Administrator** account because they need `manage_options`, `activate_plugins`, or `edit_users`. For those workflows, create a second dedicated Administrator service account and keep the Editor account for content. Using two accounts limits blast radius: the Editor account cannot touch site configuration, and the Administrator account is used only for auditing.
 

--- a/wp-mcp-abilities.php
+++ b/wp-mcp-abilities.php
@@ -3,7 +3,7 @@
  * Plugin Name: WordPress MCP Abilities
  * Plugin URI:  https://github.com/DanielBoring/wordpress-mcp-abilities
  * Description: Adds core content management abilities to the official WordPress MCP Adapter plugin, giving AI agents full editorial access: posts, pages, taxonomy, comments, health checks, security auditing, and SEO analysis.
- * Version:     1.3.1
+ * Version:     1.4.0
  * Requires at least: 6.9
  * Requires PHP: 7.4
  * Author:      Daniel Boring
@@ -41,6 +41,7 @@ add_action( 'wp_abilities_api_init', function () {
 	require_once __DIR__ . '/includes/class-posts.php';
 	require_once __DIR__ . '/includes/class-taxonomy.php';
 	require_once __DIR__ . '/includes/class-comments.php';
+	require_once __DIR__ . '/includes/class-media.php';
 	require_once __DIR__ . '/includes/class-health.php';
 	require_once __DIR__ . '/includes/class-security.php';
 	require_once __DIR__ . '/includes/class-seo.php';
@@ -48,6 +49,7 @@ add_action( 'wp_abilities_api_init', function () {
 	WP_MCP_Posts::register();
 	WP_MCP_Taxonomy::register();
 	WP_MCP_Comments::register();
+	WP_MCP_Media::register();
 	WP_MCP_Health::register();
 	WP_MCP_Security::register();
 	WP_MCP_SEO::register();


### PR DESCRIPTION
## Summary
Adds a new media ability group for WordPress attachments: list, get, update, and permanently delete media items. This implements #1 and wires the new media class into the plugin registration flow.

## Ability name (if new)
- `wp-mcp/list-media`
- `wp-mcp/get-media`
- `wp-mcp/update-media`
- `wp-mcp/delete-media`

## Security/authorization update
Addressed object-level authorization and ownership scoping issues discovered during QA:
- `list-media` now scopes Author-level users to their own attachments unless the user has `edit_others_posts`.
- `get-media` now blocks access to attachments the user does not own (unless they can edit others' posts).
- `update-media` now blocks cross-user updates with explicit permission errors.
- `delete-media` now blocks cross-user deletes unless the user can delete others' posts.

## Documentation updates
- README media section now explicitly documents Author-scope behavior for media access.
- `readme.txt` role-scope note now includes media (`upload_files`) and cross-user capability requirements (`edit_others_posts`/`delete_others_posts`).

## Testing
- Docker E2E QA: WordPress + MySQL + MCP Adapter v0.5.0 + this plugin mounted and activated.
- Confirmed all four media abilities are discoverable via MCP.
- Confirmed Author cannot list/get/update/delete another user's media.
- Confirmed Editor can update/delete own media.
- Confirmed behavior remains correct for success and permission-denied paths.