### PR TITLE
Add user lookup abilities

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Thanks for your interest in contributing. This document covers how to report bug
    wp plugin activate wp-mcp-abilities
    ```
 3. Create a test user with the Editor role and generate an application password (see README.md for details)
-4. Point your MCP client at the local site and run `mcp-adapter-discover-abilities` to confirm the 24 abilities load
+4. Point your MCP client at the local site and run `mcp-adapter-discover-abilities` to confirm the abilities load
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Only the MCP Adapter's 3 meta/discovery abilities are visible — no content too
 ![Before](assets/before.png)
 
 ### With this plugin
-All abilities available: full editorial access to posts, pages, taxonomy, comments, security, and SEO.
+All abilities available: full editorial access to posts, pages, taxonomy, comments, media, user lookup, security, and SEO.
 
 ![After](assets/after.png)
 
@@ -104,7 +104,7 @@ Each ability enforces a WordPress capability check. The table below maps standar
 | Subscriber    | `read`                                                                   | Read-only workflows: taxonomy browsing, health checks, SEO overview |
 | Author        | `edit_posts`, `delete_posts`, `upload_files`                             | Creating and managing the agent's own posts and media               |
 | **Editor** ✓  | All Author caps + `edit_pages`, `delete_pages`, `manage_categories`, `moderate_comments` | **Full editorial control — recommended default** |
-| Administrator | All Editor caps, plus extra administrative capabilities not required by the current ability set | Future admin-only audit workflows, if added |
+| Administrator | All Editor caps, plus `list_users` for user lookup and other administrative capabilities | User lookup (`list-users` / `get-user`) and future admin-only workflows |
 
 > **Scope note for `edit_posts`:** This capability is available to Authors and above, but WordPress scopes query results to the authenticated user's own content unless `edit_others_posts` is also present. An Editor account (which has `edit_others_posts`) sees all content site-wide. Use Author only if the agent should be limited to content it created.
 
@@ -157,6 +157,12 @@ Each ability enforces a WordPress capability check. The table below maps standar
 | `wp-mcp/delete-media`  | Permanently delete a media item                         | `delete_posts`      | Author    |
 
 † Author-role access is scoped to media owned by the authenticated user. Use **Editor** to manage media site-wide.
+
+### Users
+| Ability              | Description                                             | Required Capability | Min. Role     |
+| -------------------- | ------------------------------------------------------- | ------------------- | ------------- |
+| `wp-mcp/list-users`  | List users with filters (role, search, pagination)      | `list_users`        | Administrator |
+| `wp-mcp/get-user`    | Get a single user by ID                                 | `list_users`        | Administrator |
 
 ### Site Health
 | Ability                    | Description                                                                                                | Required Capability | Min. Role  |
@@ -233,7 +239,7 @@ It is recommended to create a dedicated user for your AI agent rather than using
 3. Set the **Role** to **Editor**
 4. Click **Add New User**
 
-> **Why Editor and not Administrator?** The Editor role covers all capabilities used by the current ability set (`edit_posts`, `edit_pages`, `delete_posts`, `delete_pages`, `upload_files`, `manage_categories`, `moderate_comments`, `read`). For planned audit abilities — database health, performance status, backup status, plugin audit, and user access audit — an Administrator account will be required, as those abilities need `manage_options`, `activate_plugins`, or `edit_users`. If you plan to use those abilities, create a separate Administrator service account and keep the Editor account for content workflows. See the [Role overview](#role-overview) for the full breakdown.
+> **Why Editor and not Administrator?** Editor is still the recommended default for content workflows and covers the editorial capabilities used by posts, pages, taxonomy, comments, media, health, security, and SEO (`edit_posts`, `edit_pages`, `delete_posts`, `delete_pages`, `upload_files`, `manage_categories`, `moderate_comments`, `read`). The new user lookup abilities (`list-users`, `get-user`) require `list_users`, which is typically Administrator-only. If you need those abilities, use a separate dedicated Administrator service account and keep the Editor account for day-to-day content operations. See the [Role overview](#role-overview) for the full breakdown.
 
 ### 4. Create an application password
 

--- a/includes/class-users.php
+++ b/includes/class-users.php
@@ -1,0 +1,126 @@
+<?php
+
+defined( 'ABSPATH' ) || exit;
+
+class WP_MCP_Users {
+
+	public static function register() {
+		self::register_list();
+		self::register_get();
+	}
+
+	private static function normalize( $user ) {
+		$user = get_userdata( $user );
+		if ( ! $user ) {
+			return null;
+		}
+
+		return [
+			'id'           => (int) $user->ID,
+			'login'        => $user->user_login,
+			'display_name' => $user->display_name,
+			'nicename'     => $user->user_nicename,
+			'email'        => $user->user_email,
+			'url'          => $user->user_url,
+			'roles'        => array_values( array_map( 'strval', (array) $user->roles ) ),
+			'registered'   => $user->user_registered,
+		];
+	}
+
+	private static function permission() {
+		if ( ! current_user_can( 'list_users' ) ) {
+			return new WP_Error( 'forbidden', 'Requires list_users capability.' );
+		}
+
+		return true;
+	}
+
+	private static function register_list() {
+		wp_register_ability( 'wp-mcp/list-users', [
+			'label'               => 'List Users',
+			'description'         => 'List WordPress users with optional role, search, and pagination filters.',
+			'category'            => 'wp-mcp',
+			'input_schema'        => [
+				'type'       => 'object',
+				'properties' => [
+					'role'     => [ 'type' => 'string', 'description' => 'Filter by role slug (for example: administrator, editor, author)' ],
+					'search'   => [ 'type' => 'string', 'description' => 'Searches login, email, URL, and display name' ],
+					'per_page' => [ 'type' => 'integer', 'minimum' => 1, 'maximum' => 100, 'default' => 20 ],
+					'page'     => [ 'type' => 'integer', 'minimum' => 1, 'default' => 1 ],
+					'orderby'  => [ 'type' => 'string', 'enum' => [ 'ID', 'login', 'nicename', 'email', 'url', 'registered', 'display_name' ], 'default' => 'ID' ],
+					'order'    => [ 'type' => 'string', 'enum' => [ 'ASC', 'DESC' ], 'default' => 'DESC' ],
+				],
+			],
+			'execute_callback'    => function ( $input ) {
+				$per_page = min( (int) ( $input['per_page'] ?? 20 ), 100 );
+				$page     = max( 1, (int) ( $input['page'] ?? 1 ) );
+
+				$args = [
+					'number'      => $per_page,
+					'offset'      => ( $page - 1 ) * $per_page,
+					'count_total' => true,
+					'orderby'     => $input['orderby'] ?? 'ID',
+					'order'       => strtoupper( $input['order'] ?? 'DESC' ),
+				];
+
+				if ( ! empty( $input['role'] ) ) {
+					$args['role'] = sanitize_key( $input['role'] );
+				}
+
+				if ( ! empty( $input['search'] ) ) {
+					$search = trim( sanitize_text_field( $input['search'] ), '*' );
+					if ( '' !== $search ) {
+						$args['search'] = '*' . $search . '*';
+					}
+				}
+
+				$query = new WP_User_Query( $args );
+				$users = $query->get_results();
+				$total = (int) $query->get_total();
+
+				return [
+					'success' => true,
+					'data'    => [
+						'items'       => array_values( array_filter( array_map( [ self::class, 'normalize' ], $users ) ) ),
+						'total'       => $total,
+						'total_pages' => $per_page > 0 ? (int) ceil( $total / $per_page ) : 1,
+					],
+				];
+			},
+			'permission_callback' => [ self::class, 'permission' ],
+			'meta'                => [
+				'annotations' => [ 'readonly' => true, 'destructive' => false, 'idempotent' => true ],
+				'mcp'         => [ 'public' => true, 'type' => 'tool' ],
+			],
+		] );
+	}
+
+	private static function register_get() {
+		wp_register_ability( 'wp-mcp/get-user', [
+			'label'               => 'Get User',
+			'description'         => 'Get a single WordPress user by ID.',
+			'category'            => 'wp-mcp',
+			'input_schema'        => [
+				'type'       => 'object',
+				'properties' => [
+					'user_id' => [ 'type' => 'integer', 'description' => 'User ID' ],
+				],
+				'required'   => [ 'user_id' ],
+			],
+			'execute_callback'    => function ( $input ) {
+				$user = get_user_by( 'id', absint( $input['user_id'] ) );
+
+				if ( ! $user ) {
+					return [ 'success' => false, 'error' => 'User not found.' ];
+				}
+
+				return [ 'success' => true, 'data' => self::normalize( $user ) ];
+			},
+			'permission_callback' => [ self::class, 'permission' ],
+			'meta'                => [
+				'annotations' => [ 'readonly' => true, 'destructive' => false, 'idempotent' => true ],
+				'mcp'         => [ 'public' => true, 'type' => 'tool' ],
+			],
+		] );
+	}
+}

--- a/includes/class-users.php
+++ b/includes/class-users.php
@@ -27,7 +27,7 @@ class WP_MCP_Users {
 		];
 	}
 
-	private static function permission() {
+	public static function permission() {
 		if ( ! current_user_can( 'list_users' ) ) {
 			return new WP_Error( 'forbidden', 'Requires list_users capability.' );
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: mcp, ai, automation, content-management, artificial-intelligence
 Requires at least: 6.9
 Tested up to: 7.0
 Requires PHP: 8.0
-Stable tag: 1.4.0
+Stable tag: 1.5.0
 License: GPL-2.0+
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Donate link: https://paypal.me/VirtuallyBoring
@@ -15,7 +15,7 @@ Adds content management abilities to the WordPress MCP Adapter, giving AI agents
 
 WP MCP Abilities is a companion plugin for the official [MCP Adapter](https://wordpress.org/plugins/mcp-adapter/) plugin. The MCP Adapter is a transport framework — it handles the MCP session, REST endpoint, and protocol routing — but ships with no content management abilities out of the box. Any tools an AI agent can actually call must come from plugins that register them. This plugin fills that gap, giving your AI agent the tools to take action: publish a draft, run a security audit, check site health, or analyze a post's SEO.
 
-MCP Adapter Abilities registers abilities across eight groups, giving AI agents (such as Claude) a full working vocabulary for your WordPress site:
+MCP Adapter Abilities registers abilities across nine groups, giving AI agents (such as Claude) a full working vocabulary for your WordPress site:
 
 **Posts**
 Create, read, update, and delete posts. Supports all statuses including scheduled (future) posts, category and tag assignment, and pagination.
@@ -31,6 +31,9 @@ List comments with filters, approve, trash, or mark as spam — all through the 
 
 **Media**
 List, inspect, update, and permanently delete media attachments. Supports MIME type and search filters, pagination, alt text updates, title updates, and caption updates.
+
+**Users**
+List users with role/search/pagination filters and fetch a single user by ID. Useful for resolving numeric author IDs from post and media responses.
 
 **Site Health**
 Run WordPress's built-in health tests and get results grouped by severity: critical, recommended, and good.
@@ -50,7 +53,7 @@ All abilities enforce WordPress capability checks — an editor cannot call abil
 1. Install and activate the [MCP Adapter](https://wordpress.org/plugins/mcp-adapter/) plugin first — WP MCP Abilities depends on it.
 2. Upload the `wp-mcp-abilities` folder to `/wp-content/plugins/`, or install via **Plugins > Add New > Upload Plugin**.
 3. Activate the plugin through the **Plugins** menu in WordPress.
-4. Create a dedicated WordPress user for your AI agent: go to **Users > Add New User**, set the Role to **Editor**, and save. Using a dedicated account limits access and makes it easy to revoke later.
+4. Create a dedicated WordPress user for your AI agent: go to **Users > Add New User**, set the Role to **Editor**, and save. Using a dedicated account limits access and makes it easy to revoke later. If you need user lookup abilities (`list-users`, `get-user`), create a separate dedicated **Administrator** service account because those require `list_users`.
 5. Generate an application password for that user: open the user profile, scroll to **Application Passwords**, enter a name (e.g. `Claude Code`), and click **Add New Application Password**. Copy it immediately — it is only shown once.
 6. Configure your MCP client with the site URL, the dedicated username, and the application password. All abilities are then automatically available.
 
@@ -78,7 +81,9 @@ No, but behavior differs depending on whether it is active:
 
 = What WordPress user role should I use? =
 
-For the current ability set, use the **Editor** role. It covers all capabilities the plugin currently uses: `edit_posts`, `edit_pages`, `delete_posts`, `delete_pages`, `upload_files`, `manage_categories`, `moderate_comments`, and `read`. Administrator is not needed for any of these and gives the AI agent unnecessary access to site settings, user management, and plugin installation.
+For core content workflows, use the **Editor** role. It covers the editorial capabilities used by posts, pages, taxonomy, comments, media, health, security, and SEO: `edit_posts`, `edit_pages`, `delete_posts`, `delete_pages`, `upload_files`, `manage_categories`, `moderate_comments`, and `read`.
+
+For user lookup workflows (`list-users`, `get-user`), use a separate dedicated **Administrator** account because those abilities require `list_users`.
 
 Note on role scope: the `edit_posts` and `upload_files` capabilities are available to Authors as well, but WordPress scopes results and write access to the authenticated user's own content unless `edit_others_posts` / `delete_others_posts` are also present (which Editors have). Use an Author-role account only if you intentionally want the agent limited to content it created. For full site-wide editorial control, use Editor.
 
@@ -95,6 +100,10 @@ After activation, call `mcp-adapter-discover-abilities` from your MCP client. Yo
 Delete operations for posts and pages move content to trash. Media delete permanently removes the attachment and its files. All inputs are sanitized using WordPress core functions. All operations go through the WordPress API — no direct database queries.
 
 == Changelog ==
+
+= 1.5.0 =
+* Add user lookup abilities: `list-users` and `get-user`
+* 30 abilities: posts (5), pages (5), taxonomy (6), comments (4), media (4), users (2), site health (1), security audit (1), SEO analysis (2)
 
 = 1.4.0 =
 * Add media management abilities: `list-media`, `get-media`, `update-media`, and `delete-media`
@@ -124,6 +133,9 @@ Delete operations for posts and pages move content to trash. Media delete perman
 * Security audit with fail/warn/pass buckets and remediation guidance
 
 == Upgrade Notice ==
+
+= 1.5.0 =
+Adds user lookup abilities for resolving WordPress author IDs.
 
 = 1.4.0 =
 Adds media list, get, update, and permanent delete abilities.

--- a/wp-mcp-abilities.php
+++ b/wp-mcp-abilities.php
@@ -2,8 +2,8 @@
 /**
  * Plugin Name: MCP Adapter Abilities
  * Plugin URI:  https://github.com/DanielBoring/wordpress-mcp-abilities
- * Description: Adds core content management abilities to the official WordPress MCP Adapter plugin, giving AI agents full editorial access: posts, pages, taxonomy, comments, health checks, security auditing, and SEO analysis.
- * Version:     1.4.0
+ * Description: Adds core content management abilities to the official WordPress MCP Adapter plugin, giving AI agents full editorial access: posts, pages, taxonomy, comments, media, user lookup, health checks, security auditing, and SEO analysis.
+ * Version:     1.5.0
  * Requires at least: 6.9
  * Requires PHP: 8.0
  * Author:      Daniel Boring
@@ -42,6 +42,7 @@ add_action( 'wp_abilities_api_init', function () {
 	require_once __DIR__ . '/includes/class-taxonomy.php';
 	require_once __DIR__ . '/includes/class-comments.php';
 	require_once __DIR__ . '/includes/class-media.php';
+	require_once __DIR__ . '/includes/class-users.php';
 	require_once __DIR__ . '/includes/class-health.php';
 	require_once __DIR__ . '/includes/class-security.php';
 	require_once __DIR__ . '/includes/class-seo.php';
@@ -50,6 +51,7 @@ add_action( 'wp_abilities_api_init', function () {
 	WP_MCP_Taxonomy::register();
 	WP_MCP_Comments::register();
 	WP_MCP_Media::register();
+	WP_MCP_Users::register();
 	WP_MCP_Health::register();
 	WP_MCP_Security::register();
 	WP_MCP_SEO::register();


### PR DESCRIPTION
## Summary
- Adds `wp-mcp/list-users` and `wp-mcp/get-user` in a new `includes/class-users.php` ability group.
- Requires `list_users` for both user lookup abilities and returns normalized user data for resolving numeric author IDs.
- Registers the new ability group in `wp-mcp-abilities.php`.
- Updates README/readme/CONTRIBUTING docs and bumps plugin metadata/readme changelog to 1.5.0.

Closes #2

## Local Docker QA
Ran a disposable local Docker WordPress stack from this branch with WordPress 7.0, PHP 8.3.31, MCP Adapter 0.5.0, and this plugin mounted from the working tree.

Results:
- Plugin activation: passed with `mcp-adapter` active and `wordpress-mcp-abilities` active at version 1.5.0.
- Ability registration: 36 total registered abilities, including adapter abilities plus 30 plugin abilities.
- New abilities: `list-users` as admin passed; `get-user` as admin passed; `list-users` as editor denied as expected.
- Existing ability coverage passed: `list-posts`, `get-post`, `list-pages`, `get-page`, `list-categories`, `list-tags`, `list-comments`, `approve-comment`, `list-media`, `get-media`, `update-media`, `seo-analyze-post`, `seo-site-overview`, `site-health-check`, and `security-audit`.
- PHP lint inside the WordPress container passed for `wp-mcp-abilities.php` and every file in `includes/`.
- Debug log scan after the final passing run found no fatal errors, parse errors, uncaught exceptions, or warnings.

## Note
The checked-in GitHub Actions E2E workflow still has separate workflow issues to address next; local Docker QA for this issue passed using the official WordPress MCP Adapter release asset.