### PR TITLE
Move Copilot instructions into GitHub folder

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -35,3 +35,4 @@ When asked to add, change, or release abilities, complete all applicable steps b
 6. Final response
    - Summarize changed files and the meaningful outcome.
    - Mention any validation that could not run due to missing local tools.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,3 @@
 # Agent Instructions
 
-Follow [`instructions.md`](instructions.md) for all code, documentation, ability, and release-readiness work in this repository.
-
+Follow [`.github/copilot-instructions.md`](.github/copilot-instructions.md) for all code, documentation, ability, and release-readiness work in this repository.


### PR DESCRIPTION
## Summary
- Move `instructions.md` to `.github/copilot-instructions.md`
- Update `AGENTS.md` to reference the new standard Copilot instructions path

## Validation
- Ran `git diff --check`