### PR TITLE
Separate plugin and repository changelogs

### DIFF
--- a/.github/AUTOMATION.md
+++ b/.github/AUTOMATION.md
@@ -11,7 +11,7 @@ This repository uses GitHub Actions for two purposes:
 | `pull_request` (`opened`, `synchronize`, `reopened`) | `.github/workflows/e2e-qa.yml` | Detects relevant changed files, runs E2E QA when in scope, and posts an accurate PR comment (pass/fail). |
 | `push` to `main` or `develop` | `.github/workflows/e2e-qa.yml` | Detects relevant changed files and runs E2E QA when in scope. |
 | `workflow_dispatch` | `.github/workflows/e2e-qa.yml` | Runs E2E QA on demand. |
-| `push` tag `v*` | `.github/workflows/release.yml` | Validates version/changelog alignment, builds and validates release ZIP, then publishes a GitHub release. |
+| `push` tag `v*` | `.github/workflows/release.yml` | Validates plugin version/release-note alignment, builds and validates release ZIP, then publishes a GitHub release. |
 
 ## Workflow details
 
@@ -45,7 +45,7 @@ This repository uses GitHub Actions for two purposes:
 **Execution flow**
 1. Trigger on tag push matching `v*`.
 2. Validate `tag version == plugin header version == readme stable tag`.
-3. Verify changelog notes exist for the tagged version.
+3. Verify plugin release notes exist in `readme.txt` for the tagged version.
 4. Build plugin ZIP and validate required/forbidden contents.
 5. Fail if a release for the same tag already exists.
 6. Publish release with notes from `readme.txt`.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,8 @@
 - [ ] New ability names use the `unlock-mcp-potential/` prefix and set accurate `annotations` (`readonly`, `destructive`, `idempotent`)
 - [ ] If this PR adds or changes `unlock-mcp-potential/*` abilities, `tests/e2e/abilities-manifest.json` includes matching positive and negative cases where permissions apply
 - [ ] User-facing changes update relevant docs (`README.md`, `readme.txt`, `tests/e2e/README.md`, or other affected markdown)
-- [ ] `CHANGELOG.md` is updated under `## Unreleased`
+- [ ] Plugin-facing changes update `CHANGELOG.md` under `## Unreleased`
+- [ ] Repository, CI, contributor, GitHub platform, template, or agent workflow changes update `.github/REPOSITORY_CHANGELOG.md` under `## Unreleased`
 - [ ] WordPress Coding Standards checked with `composer phpcs`, or the reason it was not run is documented above
 - [ ] WordPress.org Detailed Plugin Guidelines were considered for public-facing or release-impacting changes such as naming, readme text, privacy/external calls, licensing, bundled assets, and release packaging
 - [ ] E2E QA is passing, or failures are unrelated and explained above

--- a/.github/REPOSITORY_CHANGELOG.md
+++ b/.github/REPOSITORY_CHANGELOG.md
@@ -1,0 +1,19 @@
+# Repository Changelog
+
+Repository, CI, contributor, and GitHub platform changes are tracked here. These entries are for maintainers and should not be promoted into plugin version notes.
+
+Plugin-facing release notes belong in `CHANGELOG.md`.
+
+## Unreleased
+
+### Changed
+
+- Updated README and WordPress.org readme documentation to include plugin management abilities and administrator role requirements.
+- Clarified E2E manifest coverage documentation for the current 37 registered abilities and 57 manifest test cases.
+- Updated pull request and contribution guidance so external contributors can apply WordPress.org guideline checks when relevant and keep docs, changelogs, and E2E coverage in sync.
+- Added repository agent instructions for repeatable ability, documentation, changelog, contribution, and validation workflows.
+- Clarified that local agent validation is a preflight check and GitHub Actions remains the authoritative PR validation gate.
+
+### Fixed
+
+- Avoided Docker Compose project-name collisions between local and GitHub Actions E2E runs.

--- a/.github/SETUP-COMPLETE.md
+++ b/.github/SETUP-COMPLETE.md
@@ -17,7 +17,7 @@ Removed workflows:
 | Pull request opened/synchronized/reopened | `e2e-qa.yml` | Runs changed-file detection and executes Docker E2E QA when in scope. |
 | Push to `main` or `develop` | `e2e-qa.yml` | Runs changed-file detection and executes Docker E2E QA when in scope. |
 | Manual dispatch | `e2e-qa.yml` | Executes on-demand E2E QA run. |
-| Push tag `v*` | `release.yml` | Validates versions/changelog, builds artifact, validates contents, publishes release. |
+| Push tag `v*` | `release.yml` | Validates plugin version/release notes, builds artifact, validates contents, publishes release. |
 
 ## Contributor flow
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,14 +16,16 @@ When asked to add, change, or release abilities, complete all applicable steps b
    - Update `readme.txt` for WordPress.org-facing description, FAQ, changelog, and upgrade notice when applicable.
    - Update related markdown files such as `tests/e2e/README.md`, `CONTRIBUTING.md`, and `.github/PULL_REQUEST_TEMPLATE.md`.
 
-3. Update changelog
-   - Add all unreleased work under `CHANGELOG.md` `## Unreleased`.
-   - Keep `CHANGELOG.md` focused on plugin-facing release notes. Use user-facing ability descriptions or short ability labels; avoid raw internal ability namespace strings unless the exact MCP tool name is necessary for compatibility notes.
+3. Update changelogs
+   - Add plugin-facing unreleased work under `CHANGELOG.md` `## Unreleased`.
+   - Keep `CHANGELOG.md` focused on plugin release notes: changes that affect plugin users, MCP tool compatibility, WordPress behavior, packaged plugin functionality, security, or bug fixes.
+   - Add repository, CI, contributor, GitHub platform, template, or agent workflow changes under `.github/REPOSITORY_CHANGELOG.md` `## Unreleased`.
+   - Use user-facing ability descriptions or short ability labels in plugin release notes; avoid raw internal ability namespace strings unless the exact MCP tool name is necessary for compatibility notes.
    - Do not put new work directly under a released version unless preparing that release section.
 
 4. Validate contribution guidance
    - Keep `.github/PULL_REQUEST_TEMPLATE.md` and `CONTRIBUTING.md` in sync.
-   - The PR checklist must cover capability checks, sanitization, response shape, E2E manifest coverage, docs, changelog, PHPCS, E2E QA, and WordPress.org guideline impact where relevant.
+   - The PR checklist must cover capability checks, sanitization, response shape, E2E manifest coverage, docs, plugin/repository changelog selection, PHPCS, E2E QA, and WordPress.org guideline impact where relevant.
 
 5. Validate
    - When running locally, run available checks in the local checkout before finishing:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
           mkdir -p build
           NOTES="$(awk "/^= ${TAG_VERSION} =/{found=1; next} found && /^= /{exit} found{print}" readme.txt | sed '/^[[:space:]]*$/d')"
           if [ -z "$NOTES" ]; then
-            echo "No changelog notes found in readme.txt for version ${TAG_VERSION}" >&2
+            echo "No plugin release notes found in readme.txt for version ${TAG_VERSION}" >&2
             exit 1
           fi
           printf '%s\n' "$NOTES" > "$NOTES_FILE"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-# Changelog
+# Plugin Changelog
 
-All notable changes to Unlock MCP Potential are tracked here.
+Plugin-facing changes to Unlock MCP Potential are tracked here. Release notes and version sections should include only changes that affect plugin users, MCP tool compatibility, WordPress behavior, or packaged plugin functionality.
+
+Repository, CI, contributor, and GitHub platform changes are tracked separately in `.github/REPOSITORY_CHANGELOG.md`.
 
 ## Unreleased
 
@@ -12,16 +14,10 @@ All notable changes to Unlock MCP Potential are tracked here.
 ### Changed
 
 - Renamed registered MCP ability names and categories to the `unlock-mcp-potential` plugin slug namespace.
-- Updated README and WordPress.org readme documentation to include plugin management abilities and administrator role requirements.
-- Clarified E2E manifest coverage documentation for the current 37 registered abilities and 57 manifest test cases.
-- Updated pull request and contribution guidance so external contributors can apply WordPress.org guideline checks when relevant and keep docs, changelog, and E2E coverage in sync.
-- Added repository agent instructions for repeatable ability, documentation, changelog, contribution, and validation workflows.
-- Clarified that local agent validation is a preflight check and GitHub Actions remains the authoritative PR validation gate.
 
 ### Fixed
 
 - Preserved backslashes in `create-post` and `update-post` content by slashing post data before WordPress insert/update calls.
-- Avoided Docker Compose project-name collisions between local and GitHub Actions E2E runs.
 
 ## 1.6.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ Each group of abilities lives in its own file under `includes/`. Follow the exis
 5. **Return a consistent shape** — match the affected ability group's existing success arrays and `WP_Error`/structured error responses
 6. **Require the class file** in `unlock-mcp-potential.php` inside the `wp_abilities_api_init` action and call `ClassName::register()`
 7. **Add E2E manifest coverage** in `tests/e2e/abilities-manifest.json`; include both allowed and denied roles when permissions differ by role or capability
-8. **Update docs and changelog** when behavior is user-facing: `README.md`, `readme.txt`, relevant markdown files, and `CHANGELOG.md` under `## Unreleased`. Changelog entries should use plugin-facing release-note wording rather than raw internal ability namespace strings unless the exact MCP tool name is necessary.
+8. **Update docs and changelogs** when behavior is user-facing: `README.md`, `readme.txt`, relevant markdown files, and `CHANGELOG.md` under `## Unreleased`. Changelog entries should use plugin-facing release-note wording rather than raw internal ability namespace strings unless the exact MCP tool name is necessary. Repository, CI, contributor, GitHub platform, template, or agent workflow changes belong in `.github/REPOSITORY_CHANGELOG.md`.
 
 A minimal ability skeleton:
 
@@ -108,7 +108,7 @@ Set `annotations` accurately — `readonly: true` for read-only abilities, `dest
 3. Run `composer phpcs`
 4. Test manually against a real WordPress install — verify the ability appears in `mcp-adapter-discover-abilities` and returns correct output
 5. If the PR adds or changes abilities, update `tests/e2e/abilities-manifest.json` with matching coverage
-6. Update user-facing docs and add a `CHANGELOG.md` entry under `## Unreleased`
+6. Update user-facing docs and add a `CHANGELOG.md` entry under `## Unreleased`; use `.github/REPOSITORY_CHANGELOG.md` for repo/platform-only changes
 7. Review the WordPress.org Detailed Plugin Guidelines when the change affects naming, readme text, privacy/external calls, licensing/assets, or release packaging
 8. Open a PR with a clear description of what changed and why
 
@@ -139,8 +139,8 @@ Release checklist:
 
 1. Choose the version bump based on the rules above.
 2. Update the `Version` header in `unlock-mcp-potential.php`.
-3. Move relevant `CHANGELOG.md` entries from `## Unreleased` into the new version section.
-4. Update `Stable tag`, changelog entries, and upgrade notice in `readme.txt`.
+3. Move relevant plugin-facing `CHANGELOG.md` entries from `## Unreleased` into the new version section. Do not include `.github/REPOSITORY_CHANGELOG.md` entries in plugin release notes.
+4. Update `Stable tag`, plugin changelog entries, and upgrade notice in `readme.txt`.
 5. Confirm the generated zip uses the `unlock-mcp-potential` directory slug.
 6. Tag and push `vX.Y.Z` to trigger the release workflow.
 
@@ -149,7 +149,7 @@ Release checklist:
 ## Release process (maintainers)
 
 1. Update the `Version` header in `unlock-mcp-potential.php`
-2. Move `CHANGELOG.md` notes from `## Unreleased` into the release version
+2. Move plugin-facing `CHANGELOG.md` notes from `## Unreleased` into the release version
 3. Add release notes to `readme.txt` under `== Changelog ==` and `== Upgrade Notice ==`
 4. Commit: `git commit -m "chore: release v1.x.x"`
 5. Tag and push: `git tag v1.x.x && git push origin v1.x.x`


### PR DESCRIPTION
## Summary
- Keep `CHANGELOG.md` focused on plugin-facing release notes only
- Add `.github/REPOSITORY_CHANGELOG.md` for repository, CI, contributor, GitHub platform, template, and agent workflow changes
- Update contributor/Copilot/PR template/release automation wording so version releases only promote plugin-facing notes

## Validation
- `git diff --check`