### PR TITLE
Prepare corrected 1.6.0 release notes

### DIFF
--- a/.github/REPOSITORY_CHANGELOG.md
+++ b/.github/REPOSITORY_CHANGELOG.md
@@ -6,14 +6,44 @@ Plugin-facing release notes belong in `CHANGELOG.md`.
 
 ## Unreleased
 
+No unreleased repository changes.
+
+## 1.6.0
+
+### Added
+
+- Added WordPress Coding Standards tooling via Composer and `phpcs.xml.dist`.
+- Added contribution and PR checklist guidance for WordPress.org Detailed Plugin Guidelines review.
+- Added manifest-driven E2E ability coverage via `tests/e2e/abilities-manifest.json` and `tests/e2e/ability-runner.php`.
+- Added an E2E coverage gate that fails when any registered `unlock-mcp-potential/*` ability is missing from the manifest.
+- Added E2E execution coverage for the current 33 registered abilities with 45 manifest test cases, including positive and negative permission cases.
+- Added E2E PR comments that report ability coverage counts, tested dependency versions, commit SHA, and workflow run URL.
+- Added failure artifact collection for E2E failures, including Docker Compose logs, WordPress debug logs, and E2E summary JSON.
+- Added E2E documentation in `tests/e2e/README.md` describing the rule that new or changed abilities must include manifest test coverage.
+- Added a pull request checklist reminder to update `tests/e2e/abilities-manifest.json` when abilities are added or changed.
+
 ### Changed
 
 - Updated README and WordPress.org readme documentation to include plugin management abilities and administrator role requirements.
+- Updated repository/documentation references to align with the Unlock MCP Potential package rebrand.
+- Replaced generic `WP_MCP_` PHP class prefixes with `Unlock_MCP_`.
 - Clarified E2E manifest coverage documentation for the current 37 registered abilities and 57 manifest test cases.
 - Updated pull request and contribution guidance so external contributors can apply WordPress.org guideline checks when relevant and keep docs, changelogs, and E2E coverage in sync.
 - Added repository agent instructions for repeatable ability, documentation, changelog, contribution, and validation workflows.
 - Clarified that local agent validation is a preflight check and GitHub Actions remains the authoritative PR validation gate.
+- Consolidated release automation to the tag-based `release.yml` workflow.
+- Hardened release validation to check tag, plugin header, `readme.txt` stable tag, plugin release notes, artifact contents, and duplicate release state before publishing.
+- Updated E2E Docker testing to run against WordPress 7.0 with PHP 8.2 and MySQL 8.0.36.
+- Pinned GitHub Actions to immutable commit SHAs and updated `actions/checkout` to a Node.js 24-compatible release.
+- Split E2E PR commenting into a separate no-checkout job with write permissions isolated from PR-controlled code execution.
 
 ### Fixed
 
 - Avoided Docker Compose project-name collisions between local and GitHub Actions E2E runs.
+
+### Removed
+
+- Removed redundant `auto-close-issue.yml` automation in favor of GitHub's native `Closes #N` / `Fixes #N` / `Resolves #N` behavior.
+- Removed `auto-pr-from-issue.yml` placeholder PR automation.
+- Removed merge-based `auto-release.yml` automation to avoid overlapping release paths.
+- Removed `.github/README.md` so GitHub shows the project root `README.md` on the repository homepage.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,53 +6,26 @@ Repository, CI, contributor, and GitHub platform changes are tracked separately 
 
 ## Unreleased
 
-### Added
-
-- Added featured image abilities for setting and removing featured images on posts and pages, with E2E manifest coverage.
-- Added restore abilities for restoring trashed posts and pages, with object-specific `delete_post` permission checks and E2E manifest coverage.
-
-### Changed
-
-- Renamed registered MCP ability names and categories to the `unlock-mcp-potential` plugin slug namespace.
-
-### Fixed
-
-- Preserved backslashes in `create-post` and `update-post` content by slashing post data before WordPress insert/update calls.
+No unreleased plugin-facing changes.
 
 ## 1.6.0
 
 ### Added
 
-- Added WordPress Coding Standards tooling via Composer and `phpcs.xml.dist`.
-- Added contribution and PR checklist guidance for WordPress.org Detailed Plugin Guidelines review.
-- Added manifest-driven E2E ability coverage via `tests/e2e/abilities-manifest.json` and `tests/e2e/ability-runner.php`.
-- Added an E2E coverage gate that fails when any registered `unlock-mcp-potential/*` ability is missing from the manifest.
-- Added E2E execution coverage for the current 33 registered abilities with 45 manifest test cases, including positive and negative permission cases.
-- Added E2E PR comments that report ability coverage counts, tested dependency versions, commit SHA, and workflow run URL.
-- Added failure artifact collection for E2E failures, including Docker Compose logs, WordPress debug logs, and E2E summary JSON.
-- Added E2E documentation in `tests/e2e/README.md` describing the rule that new or changed abilities must include manifest test coverage.
-- Added a pull request checklist reminder to update `tests/e2e/abilities-manifest.json` when abilities are added or changed.
+- Added featured image abilities for setting and removing featured images on posts and pages.
+- Added restore abilities for restoring trashed posts and pages, with object-specific `delete_post` permission checks.
 - Added plugin management abilities: `list-plugins`, `activate-plugin`, and `deactivate-plugin`.
 - Added guarded plugin state controls with canonical `plugin_basename` identifiers, protected-plugin deactivation safeguards (`force` override), multisite-aware `network_wide` handling, and structured `WP_Error` responses for capability/context/identifier failures.
 
 ### Changed
 
-- Renamed the plugin to "Unlock MCP Potential" and updated release/test tooling for the `unlock-mcp-potential` plugin slug.
-- Updated repository/documentation references to align with the Unlock MCP Potential package rebrand.
-- Replaced generic `WP_MCP_` PHP class prefixes with `Unlock_MCP_`.
+- Renamed registered MCP ability names and categories to the `unlock-mcp-potential` plugin slug namespace.
+- Renamed the plugin to "Unlock MCP Potential" and updated plugin references for the `unlock-mcp-potential` slug.
 - Hardened permission callbacks for object-specific post/media operations and sensitive site-audit abilities.
-- Consolidated release automation to the tag-based `release.yml` workflow.
-- Hardened release validation to check tag, plugin header, `readme.txt` stable tag, changelog notes, artifact contents, and duplicate release state before publishing.
-- Updated E2E Docker testing to run against WordPress 7.0 with PHP 8.2 and MySQL 8.0.36.
-- Pinned GitHub Actions to immutable commit SHAs and updated `actions/checkout` to a Node.js 24-compatible release.
-- Split E2E PR commenting into a separate no-checkout job with write permissions isolated from PR-controlled code execution.
 
-### Removed
+### Fixed
 
-- Removed redundant `auto-close-issue.yml` automation in favor of GitHub's native `Closes #N` / `Fixes #N` / `Resolves #N` behavior.
-- Removed `auto-pr-from-issue.yml` placeholder PR automation.
-- Removed merge-based `auto-release.yml` automation to avoid overlapping release paths.
-- Removed `.github/README.md` so GitHub shows the project root `README.md` on the repository homepage.
+- Preserved backslashes in `create-post` and `update-post` content by slashing post data before WordPress insert/update calls.
 
 ## 1.5.0
 

--- a/readme.txt
+++ b/readme.txt
@@ -105,10 +105,13 @@ Delete operations for posts and pages move content to trash. Media delete perman
 == Changelog ==
 
 = 1.6.0 =
+* Rename registered MCP ability names and categories to the `unlock-mcp-potential` plugin slug namespace
+* Add featured image abilities for setting and removing featured images on posts and pages
+* Add restore abilities for restoring trashed posts and pages with object-specific `delete_post` permission checks
+* Preserve backslashes in `create-post` and `update-post` content
 * Add plugin management abilities: `list-plugins`, `activate-plugin`, and `deactivate-plugin`
 * Add guarded plugin activation/deactivation controls with canonical `plugin_basename` identifiers, protected-plugin safeguards, multisite-aware `network_wide` handling, and structured errors
-* Add E2E manifest coverage and release QA/reporting hardening for ability lifecycle changes
-* Rebrand package/repository references to align with Unlock MCP Potential and remove `.github/README.md` so GitHub uses the root README
+* Rename plugin/package references to align with Unlock MCP Potential and harden object-specific permission callbacks
 
 = 1.5.1 =
 * Rename plugin to "Unlock MCP Potential" and update slug references to `unlock-mcp-potential`
@@ -150,7 +153,7 @@ Delete operations for posts and pages move content to trash. Media delete perman
 == Upgrade Notice ==
 
 = 1.6.0 =
-Adds plugin management abilities and guarded activation controls, plus release and coverage hardening updates.
+Renames MCP ability IDs to the `unlock-mcp-potential` namespace, adds featured image, restore, and plugin management abilities, and fixes post content backslash preservation.
 
 = 1.5.1 =
 Renames the plugin, tightens permission checks, and adds WordPress.org review-readiness tooling.


### PR DESCRIPTION
## Summary
- Move 1.6.0 repository/GitHub platform updates from the plugin changelog into `.github/REPOSITORY_CHANGELOG.md`
- Promote current plugin-facing Unreleased entries into the `1.6.0` plugin changelog section
- Update `readme.txt` 1.6.0 changelog and upgrade notice so the rerelease notes are plugin-focused

## Validation
- `git diff --check`