### PR TITLE
Release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Repository, CI, contributor, and GitHub platform changes are tracked separately 
 
 ## Unreleased
 
+## 2.1.0
+
 ### Added
 
 - Added `list-content-blocks` and `patch-content-block` for precise Gutenberg block inspection and single-block replacement in posts and pages.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
     </a>
   </h2>
 
-[Quickstart](#quickstart) • [Abilities](#abilities) • [Requirements](#requirements) • [Installation](#installation) • [Verification](#verification) • [Security](#security) • [Full docs ↗](https://www.virtuallyboring.com/unlock-mcp-potential/)
+[Quickstart](#quickstart) • [Abilities](#abilities) • [Requirements](#requirements) • [Installation](#installation) • [Verification](#verification) • [Security](#security) • [Full docs ↗](https://www.virtuallyboring.com/webmastery-site-toolkit-for-mcp/)
 
 </div>
 
@@ -36,7 +36,7 @@ Without this plugin, the MCP Adapter exposes only its 3 meta/discovery abilities
 <td align="center"><strong>With this plugin</strong><br/><img src="assets/after.png" alt="After"></td></tr>
 </table>
 
-> 📖 **Full reference** — the complete ability tables, architecture diagram, and extended security notes live on the project page: **[virtuallyboring.com/unlock-mcp-potential](https://www.virtuallyboring.com/unlock-mcp-potential/)**.
+> 📖 **Full reference** — the complete ability tables, architecture diagram, and extended security notes live on the project page: **[virtuallyboring.com/webmastery-site-toolkit-for-mcp](https://www.virtuallyboring.com/webmastery-site-toolkit-for-mcp/)**.
 
 ---
 
@@ -72,7 +72,7 @@ Every ability enforces a WordPress capability check, so the tools an agent can c
 
 Post and page body edits can use `list-content-blocks` to inspect block paths and hashes, then `patch-content-block` to replace one exact Gutenberg block by path or unique hash. `patch-post-content` remains available for heading-section edits and strict exact-match replacement. Ambiguous, missing, or stale targets fail instead of guessing.
 
-👉 **[See the full ability reference](https://www.virtuallyboring.com/unlock-mcp-potential/#available-abilities)** for every ability, its description, required capability, and minimum role.
+👉 **[See the full ability reference](https://www.virtuallyboring.com/webmastery-site-toolkit-for-mcp/#available-abilities)** for every ability, its description, required capability, and minimum role.
 
 ---
 
@@ -196,7 +196,7 @@ To confirm everything works, ask your agent to call a few:
 - `patch-content-block` and `patch-post-content` support optional hash preconditions and fail safely when a target is missing, ambiguous, or stale.
 - Content is sanitized on write, and there are **no direct database queries** — all reads and writes go through the WordPress API.
 
-📖 **[Full security model](https://www.virtuallyboring.com/unlock-mcp-potential/#security)**, including plugin-management safeguards and the complete sanitization rules.
+📖 **[Full security model](https://www.virtuallyboring.com/webmastery-site-toolkit-for-mcp/#security)**, including plugin-management safeguards and the complete sanitization rules.
 
 ---
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: mcp, ai, automation, content-management, artificial-intelligence
 Requires at least: 6.9
 Tested up to: 7.0
 Requires PHP: 8.0
-Stable tag: 2.0.0
+Stable tag: 2.1.0
 License: GPL-2.0+
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Donate link: https://paypal.me/VirtuallyBoring
@@ -170,6 +170,9 @@ For post and page body edits, `list-content-blocks` returns precise block paths 
 * Security audit with fail/warn/pass buckets and remediation guidance
 
 == Upgrade Notice ==
+
+= 2.1.0 =
+Adds safer block-level post and page editing abilities for MCP clients.
 
 = 2.0.0 =
 Renames MCP ability IDs to the `webmastery-site-toolkit-for-mcp` namespace as part of the WordPress.org review rename.

--- a/webmastery-site-toolkit-for-mcp.php
+++ b/webmastery-site-toolkit-for-mcp.php
@@ -1,9 +1,9 @@
 <?php
 /**
  * Plugin Name: Webmastery Site Toolkit for MCP
- * Plugin URI:  https://github.com/DanielBoring/webmastery-site-toolkit-for-mcp
+ * Plugin URI:  https://www.virtuallyboring.com/webmastery-site-toolkit-for-mcp/
  * Description: Adds site management abilities for MCP-powered WordPress workflows: posts, pages, taxonomy, comments, media, plugins, user lookup, health checks, security auditing, and SEO analysis.
- * Version:     2.0.0
+ * Version:     2.1.0
  * Requires at least: 6.9
  * Requires PHP: 8.0
  * Author:      Daniel Boring


### PR DESCRIPTION
## Summary

Prepares the v2.1.0 release for the block-level content editing abilities merged in #51.

- Bumps the plugin header version to `2.1.0`.
- Updates `readme.txt` Stable tag to `2.1.0`.
- Moves the block-editing release notes into `CHANGELOG.md` `## 2.1.0`.
- Adds the `2.1.0` upgrade notice in `readme.txt`.
- Sets the plugin website/reference links to `https://www.virtuallyboring.com/webmastery-site-toolkit-for-mcp/`.

## Validation

- `php vendor/bin/phpcs --standard=phpcs.xml.dist`
- `git diff --check`
- Version alignment check: plugin header `2.1.0`, readme Stable tag `2.1.0`, readme release notes present
- `bash scripts/e2e-test.sh`: 40 abilities covered, 72 passed, 0 failed