### PR TITLE
Prepare v2.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Repository, CI, contributor, and GitHub platform changes are tracked separately 
 
 ## Unreleased
 
+## 2.2.0
+
 ### Added
 
 - Added Yoast SEO score and readability score abilities with pagination, filters, deterministic newest-modified-first ordering, and explicit empty results when Yoast SEO is not active.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: mcp, ai, automation, content-management, artificial-intelligence
 Requires at least: 6.9
 Tested up to: 7.0
 Requires PHP: 8.0
-Stable tag: 2.1.0
+Stable tag: 2.2.0
 License: GPL-2.0+
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Donate link: https://paypal.me/VirtuallyBoring
@@ -113,6 +113,10 @@ For post and page body edits, `list-content-blocks` returns precise block paths 
 
 == Changelog ==
 
+= 2.2.0 =
+* Add Yoast SEO score and readability score abilities with pagination, filters, deterministic newest-modified-first ordering, and explicit empty results when Yoast SEO is not active.
+* Persist supported Yoast SEO protected meta keys from post and page create/update abilities, including focus keyphrase, meta description, and SEO title, and return structured `meta_write_failed` details for meta keys that are not writable.
+
 = 2.1.0 =
 * Add `list-content-blocks` and `patch-content-block` for precise Gutenberg block inspection and single-block replacement in posts and pages.
 * Add `patch-post-content` for safer partial post body edits with block-aware heading targeting, exact-match fallback, ambiguous-target failures, and optional content-hash preconditions.
@@ -174,6 +178,9 @@ For post and page body edits, `list-content-blocks` returns precise block paths 
 * Security audit with fail/warn/pass buckets and remediation guidance
 
 == Upgrade Notice ==
+
+= 2.2.0 =
+Adds Yoast score list abilities and fixes supported Yoast protected meta writes for post and page create/update workflows.
 
 = 2.1.0 =
 Adds safer block-level post and page editing abilities for MCP clients.

--- a/webmastery-site-toolkit-for-mcp.php
+++ b/webmastery-site-toolkit-for-mcp.php
@@ -3,7 +3,7 @@
  * Plugin Name: Webmastery Site Toolkit for MCP
  * Plugin URI:  https://www.virtuallyboring.com/webmastery-site-toolkit-for-mcp/
  * Description: Adds site management abilities for MCP-powered WordPress workflows: posts, pages, taxonomy, comments, media, plugins, user lookup, health checks, security auditing, and SEO analysis.
- * Version:     2.1.0
+ * Version:     2.2.0
  * Requires at least: 6.9
  * Requires PHP: 8.0
  * Author:      Daniel Boring


### PR DESCRIPTION
## Summary

- Bump plugin header and WordPress.org stable tag to `2.2.0`
- Move Yoast score abilities and protected-meta persistence notes from `CHANGELOG.md` Unreleased into `2.2.0`
- Add WordPress.org `readme.txt` changelog and upgrade notice for `2.2.0`

## Validation

- `git diff --check`
- Release metadata check: plugin header, stable tag, and readme release notes all match `2.2.0`
- Release zip shape check: canonical `webmastery-site-toolkit-for-mcp` top-level folder, no dev/test files
- `composer phpcs` via Composer Docker image
- Docker E2E: 42 registered abilities, 42 covered abilities, 78 manifest cases, 78 passed / 0 failed
- Plugin Check 2.0.0 against package-only copy: no unexpected errors; only documented warnings for auto-update status reporting and bounded Yoast meta queries
