### PR TITLE
Improve local QA workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
 <!-- e.g. webmastery-site-toolkit-for-mcp/list-media — leave blank for bug fixes -->
 
 ## Testing
-<!-- How did you verify this works? List the ability calls you ran and what they returned. -->
+<!-- How did you verify this works? Include local QA commands such as composer qa, scripts/qa-local.sh --e2e, or scripts/qa-local.ps1 -E2E, plus any manual ability calls and what they returned. -->
 <!-- E2E QA tests will run automatically on push. -->
 
 ## Checklist
@@ -20,6 +20,6 @@
 - [ ] User-facing changes update relevant docs (`README.md`, `readme.txt`, `tests/e2e/README.md`, or other affected markdown)
 - [ ] Plugin-facing changes update `CHANGELOG.md` under `## Unreleased`
 - [ ] Repository, CI, contributor, GitHub platform, template, or agent workflow changes update `.github/REPOSITORY_CHANGELOG.md` under `## Unreleased`
-- [ ] WordPress Coding Standards checked with `composer phpcs`, or the reason it was not run is documented above
+- [ ] Local QA checked with `composer qa` or the reason it was not run is documented above
 - [ ] WordPress.org Detailed Plugin Guidelines were considered for public-facing or release-impacting changes such as naming, readme text, privacy/external calls, licensing, bundled assets, and release packaging
 - [ ] E2E QA is passing, or failures are unrelated and explained above

--- a/.github/REPOSITORY_CHANGELOG.md
+++ b/.github/REPOSITORY_CHANGELOG.md
@@ -8,11 +8,13 @@ Plugin-facing release notes belong in `CHANGELOG.md`.
 
 ### Added
 
+- Added cross-platform local QA helper scripts, a Composer QA command, and a lightweight E2E manifest validator for contributor preflight checks.
 - Added a dedicated Coding Standards workflow that installs Composer dev dependencies and runs PHPCS on pushes, pull requests, and manual dispatches.
 - Added an E2E mu-plugin fixture for custom post type ability coverage.
 
 ### Changed
 
+- Updated E2E runner behavior so local runs can optionally manage Docker Compose startup and cleanup while preserving CI behavior.
 - Updated E2E ability manifest coverage counts and cases for bulk post operation abilities.
 - Updated release, E2E, PHPCS, Composer, and documentation automation references for the Webmastery Site Toolkit for MCP package rename.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,16 +43,18 @@ This plugin follows [WordPress Coding Standards](https://developer.wordpress.org
 
 - **Sanitize inputs** — use `sanitize_text_field()` for strings, `absint()` for IDs, `wp_kses_post()` for HTML content, and enum validation for fixed-value fields
 - **Capability checks** — every ability must have a `permission_callback` that returns a `WP_Error` on failure, not just `false`; prefer object-specific checks such as `edit_post` / `delete_post` when an object ID is available
-- **No direct database queries** — use WordPress API functions (`get_posts()`, `wp_insert_post()`, etc.) exclusively
+- **Prefer WordPress APIs** — use WordPress API functions (`get_posts()`, `wp_insert_post()`, etc.) for normal reads and writes. Direct `$wpdb` reads are limited to administrator-only diagnostics such as database health checks, must be prepared where variables are present, and must surface query errors.
 - **No output buffering** — abilities return arrays or `WP_Error` objects; the MCP Adapter handles serialization
 - **WordPress.org readiness** — avoid trademark-confusing names, spammy readme text, undisclosed external calls, bundled duplicate libraries, and non-GPL-compatible assets
 
-Run standards checks before opening a PR:
+Run local QA before opening a PR:
 
 ```bash
 composer install
-composer phpcs
+composer qa
 ```
+
+`composer qa` runs WordPress Coding Standards, the lightweight E2E manifest validator, and `git diff --check`.
 
 ---
 
@@ -105,12 +107,34 @@ Set `annotations` accurately — `readonly: true` for read-only abilities, `dest
 
 1. Fork the repo and create a branch from `main` (`feature/your-feature` or `fix/your-bug`)
 2. Make your changes following the conventions above
-3. Run `composer phpcs`
+3. Run local QA with `composer qa` or one of the helper scripts below
 4. Test manually against a real WordPress install — verify the ability appears in the MCP Adapter discovery tool, `mcp-adapter-discover-abilities`, and returns correct output
 5. If the PR adds or changes abilities, update `tests/e2e/abilities-manifest.json` with matching coverage
 6. Update user-facing docs and add a `CHANGELOG.md` entry under `## Unreleased`; use `.github/REPOSITORY_CHANGELOG.md` for repo/platform-only changes
 7. Review the WordPress.org Detailed Plugin Guidelines when the change affects naming, readme text, privacy/external calls, licensing/assets, or release packaging
 8. Open a PR with a clear description of what changed and why
+
+---
+
+## Local QA commands
+
+Use the fastest command that covers your change:
+
+| Command | What it runs |
+| --- | --- |
+| `composer qa` | PHPCS, lightweight E2E manifest validation, and `git diff --check` |
+| `composer e2e` | Docker WordPress E2E against an already-running Compose stack |
+| `E2E_MANAGE_COMPOSE=1 composer e2e` | Docker WordPress E2E with automatic Compose startup and cleanup |
+| `scripts/qa-local.sh --e2e` | Unix/Git Bash wrapper for Composer QA plus managed Docker E2E |
+| `powershell -ExecutionPolicy Bypass -File scripts/qa-local.ps1 -E2E` | PowerShell wrapper for Composer QA plus managed Docker E2E |
+
+For Windows, install PHP and Composer first, then restart your terminal so both commands are available on `PATH`. If a Windows Composer installation cannot invoke `vendor/bin/phpcs` by name, run the equivalent direct fallback:
+
+```powershell
+php vendor\squizlabs\php_codesniffer\bin\phpcs --standard=phpcs.xml.dist
+```
+
+The lightweight manifest validator checks JSON structure, expected fields, roles, labels, and assertion shapes. Full ability registration coverage still requires Docker E2E because registered abilities are only available inside WordPress after the plugin and MCP Adapter load.
 
 ---
 

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,16 @@
 		"wp-coding-standards/wpcs": "^3.1"
 	},
 	"scripts": {
+		"diff-check": "git diff --check",
+		"e2e": "bash scripts/e2e-test.sh",
 		"phpcs": "phpcs --standard=phpcs.xml.dist",
-		"phpcbf": "phpcbf --standard=phpcs.xml.dist"
+		"phpcbf": "phpcbf --standard=phpcs.xml.dist",
+		"qa": [
+			"@phpcs",
+			"@validate:e2e-manifest",
+			"@diff-check"
+		],
+		"validate:e2e-manifest": "php scripts/validate-e2e-manifest.php"
 	},
 	"config": {
 		"allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8c34f1cd2415d20956d7929d5f4f6591",
+    "content-hash": "0e9440e805a04ea9d6bf509d7b408742",
     "packages": [],
     "packages-dev": [
         {

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -5,6 +5,8 @@ WORDPRESS_URL="${WORDPRESS_URL:-http://localhost}"
 PLUGIN_SLUG="webmastery-site-toolkit-for-mcp"
 MCP_ADAPTER_ZIP="https://github.com/WordPress/mcp-adapter/releases/download/v0.5.0/mcp-adapter.zip"
 E2E_ARTIFACTS_DIR="${E2E_ARTIFACTS_DIR:-e2e-artifacts}"
+E2E_MANAGE_COMPOSE="${E2E_MANAGE_COMPOSE:-0}"
+E2E_KEEP_COMPOSE="${E2E_KEEP_COMPOSE:-0}"
 
 compose() {
 	local project_args=()
@@ -21,6 +23,27 @@ compose() {
 
 wp() {
 	compose exec -T wordpress wp --allow-root "$@"
+}
+
+start_compose() {
+	if [ "$E2E_MANAGE_COMPOSE" != "1" ]; then
+		return 0
+	fi
+
+	echo "Starting Docker Compose stack..."
+	export MYSQL_PORT="${MYSQL_PORT:-0}"
+	export WORDPRESS_PORT="${WORDPRESS_PORT:-0}"
+	compose down -v --remove-orphans
+	compose up -d
+}
+
+cleanup_compose() {
+	if [ "$E2E_MANAGE_COMPOSE" != "1" ] || [ "$E2E_KEEP_COMPOSE" = "1" ]; then
+		return 0
+	fi
+
+	echo "Stopping Docker Compose stack..."
+	compose down -v --remove-orphans
 }
 
 wait_for_wordpress_files() {
@@ -106,8 +129,11 @@ echo "================================"
 echo "E2E Test Suite: WordPress MCP Abilities"
 echo "================================"
 
+trap cleanup_compose EXIT
+
 rm -rf "$E2E_ARTIFACTS_DIR"
 mkdir -p "$E2E_ARTIFACTS_DIR"
+start_compose
 wait_for_wordpress_files
 install_wp_cli
 install_wordpress

--- a/scripts/qa-local.ps1
+++ b/scripts/qa-local.ps1
@@ -1,0 +1,46 @@
+param(
+	[switch] $E2E,
+	[switch] $KeepCompose
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Invoke-QACommand {
+	param(
+		[string] $Label,
+		[string] $FilePath,
+		[string[]] $ArgumentList
+	)
+
+	Write-Host "==> $Label"
+	& $FilePath @ArgumentList
+	if ($LASTEXITCODE -ne 0) {
+		throw "$Label failed with exit code $LASTEXITCODE."
+	}
+}
+
+function Test-QACommand {
+	param([string] $Name)
+
+	if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+		throw "Missing required command: $Name"
+	}
+}
+
+Test-QACommand 'php'
+Test-QACommand 'composer'
+Test-QACommand 'git'
+
+Invoke-QACommand 'Install Composer dependencies' 'composer' @('install', '--no-interaction')
+Invoke-QACommand 'Run Composer QA checks' 'composer' @('qa')
+
+if ($E2E) {
+	Test-QACommand 'docker'
+	Test-QACommand 'bash'
+
+	$keepComposeValue = if ($KeepCompose) { '1' } else { '0' }
+
+	Invoke-QACommand 'Run Docker E2E QA' 'bash' @('-lc', "E2E_MANAGE_COMPOSE=1 E2E_KEEP_COMPOSE=$keepComposeValue bash scripts/e2e-test.sh")
+}
+
+Write-Host 'Local QA completed successfully.'

--- a/scripts/qa-local.sh
+++ b/scripts/qa-local.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+RUN_E2E=0
+KEEP_COMPOSE=0
+
+usage() {
+	cat <<'USAGE'
+Usage: scripts/qa-local.sh [--e2e] [--keep-compose]
+
+Runs local preflight QA:
+  - composer install --no-interaction
+  - composer qa
+  - optional Docker E2E via scripts/e2e-test.sh
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		--e2e)
+			RUN_E2E=1
+			;;
+		--keep-compose)
+			KEEP_COMPOSE=1
+			;;
+		-h|--help)
+			usage
+			exit 0
+			;;
+		*)
+			echo "Unknown argument: $1" >&2
+			usage >&2
+			exit 1
+			;;
+	esac
+	shift
+done
+
+require_command() {
+	if ! command -v "$1" >/dev/null 2>&1; then
+		echo "Missing required command: $1" >&2
+		exit 1
+	fi
+}
+
+run_step() {
+	echo "==> $*"
+	"$@"
+}
+
+require_command php
+require_command composer
+require_command git
+
+run_step composer install --no-interaction
+run_step composer qa
+
+if [ "$RUN_E2E" = "1" ]; then
+	require_command docker
+	require_command bash
+
+	E2E_MANAGE_COMPOSE=1 E2E_KEEP_COMPOSE="$KEEP_COMPOSE" run_step bash scripts/e2e-test.sh
+fi
+
+echo "Local QA completed successfully."

--- a/scripts/validate-e2e-manifest.php
+++ b/scripts/validate-e2e-manifest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+$repo_root     = dirname(__DIR__);
+$manifest_path = $repo_root . '/tests/e2e/abilities-manifest.json';
+$allowed_roles = array(
+	'admin'        => true,
+	'author'       => true,
+	'book_manager' => true,
+	'case_manager' => true,
+	'editor'       => true,
+	'no_role'      => true,
+	'subscriber'   => true,
+);
+
+function webmastery_mcp_manifest_fail( array $errors ): void {
+	foreach ( $errors as $error ) {
+		fwrite( STDERR, "ERROR {$error}\n" );
+	}
+
+	exit( 1 );
+}
+
+function webmastery_mcp_manifest_path( int $index, string $field ): string {
+	return "case {$index} {$field}";
+}
+
+if ( ! file_exists( $manifest_path ) ) {
+	webmastery_mcp_manifest_fail( array( "Missing manifest: {$manifest_path}" ) );
+}
+
+$raw = file_get_contents( $manifest_path );
+if ( false === $raw ) {
+	webmastery_mcp_manifest_fail( array( "Could not read manifest: {$manifest_path}" ) );
+}
+
+$manifest = json_decode( $raw, true );
+if ( JSON_ERROR_NONE !== json_last_error() ) {
+	webmastery_mcp_manifest_fail( array( 'Invalid JSON: ' . json_last_error_msg() ) );
+}
+
+if ( ! is_array( $manifest ) ) {
+	webmastery_mcp_manifest_fail( array( 'Manifest root must be an array.' ) );
+}
+
+$errors          = array();
+$labels          = array();
+$ability_summary = array();
+
+foreach ( $manifest as $index => $case ) {
+	$case_number = $index + 1;
+
+	if ( ! is_array( $case ) ) {
+		$errors[] = "case {$case_number} must be an object.";
+		continue;
+	}
+
+	foreach ( array( 'ability', 'label', 'expect' ) as $field ) {
+		if ( ! isset( $case[ $field ] ) || ! is_string( $case[ $field ] ) || '' === trim( $case[ $field ] ) ) {
+			$errors[] = webmastery_mcp_manifest_path( $case_number, $field ) . ' must be a non-empty string.';
+		}
+	}
+
+	$ability = (string) ( $case['ability'] ?? '' );
+	if ( '' !== $ability && ! str_starts_with( $ability, 'webmastery-site-toolkit-for-mcp/' ) ) {
+		$errors[] = webmastery_mcp_manifest_path( $case_number, 'ability' ) . ' must use the webmastery-site-toolkit-for-mcp/ prefix.';
+	}
+
+	$label = (string) ( $case['label'] ?? '' );
+	if ( '' !== $label ) {
+		if ( isset( $labels[ $label ] ) ) {
+			$errors[] = "case {$case_number} label duplicates case {$labels[ $label ]}: {$label}";
+		}
+		$labels[ $label ] = $case_number;
+	}
+
+	$expect = (string) ( $case['expect'] ?? '' );
+	if ( '' !== $expect && ! in_array( $expect, array( 'success', 'failure' ), true ) ) {
+		$errors[] = webmastery_mcp_manifest_path( $case_number, 'expect' ) . ' must be success or failure.';
+	}
+
+	$role = (string) ( $case['role'] ?? 'subscriber' );
+	if ( ! isset( $allowed_roles[ $role ] ) ) {
+		$errors[] = webmastery_mcp_manifest_path( $case_number, 'role' ) . " uses unknown role: {$role}";
+	}
+
+	if ( array_key_exists( 'assert_values', $case ) && ! is_array( $case['assert_values'] ) ) {
+		$errors[] = webmastery_mcp_manifest_path( $case_number, 'assert_values' ) . ' must be an object.';
+	}
+
+	foreach ( array( 'assert_paths', 'assert_contains', 'assert_not_contains' ) as $field ) {
+		if ( array_key_exists( $field, $case ) && ! is_array( $case[ $field ] ) ) {
+			$errors[] = webmastery_mcp_manifest_path( $case_number, $field ) . ' must be an array.';
+		}
+	}
+
+	if ( '' !== $ability ) {
+		if ( ! isset( $ability_summary[ $ability ] ) ) {
+			$ability_summary[ $ability ] = array(
+				'success' => 0,
+				'failure' => 0,
+			);
+		}
+
+		if ( isset( $ability_summary[ $ability ][ $expect ] ) ) {
+			$ability_summary[ $ability ][ $expect ]++;
+		}
+	}
+}
+
+foreach ( $ability_summary as $ability => $summary ) {
+	if ( 0 === $summary['success'] ) {
+		$errors[] = "{$ability} must include at least one success case.";
+	}
+	if ( $summary['failure'] > 0 && 0 === $summary['success'] ) {
+		$errors[] = "{$ability} has failure cases but no success case.";
+	}
+}
+
+if ( $errors ) {
+	webmastery_mcp_manifest_fail( $errors );
+}
+
+ksort( $ability_summary );
+
+$negative_cases = 0;
+foreach ( $ability_summary as $summary ) {
+	$negative_cases += $summary['failure'];
+}
+
+printf(
+	"PASS E2E manifest structure: %d abilities, %d cases, %d negative cases\n",
+	count( $ability_summary ),
+	count( $manifest ),
+	$negative_cases
+);

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -25,6 +25,44 @@ For abilities with role or capability restrictions, include both:
 6. Executes every manifest case through `wp_get_ability()->execute()`.
 7. Writes `e2e-artifacts/e2e-summary.json` with coverage and result counts.
 
+## Local QA entry points
+
+For quick local checks that do not require WordPress, run:
+
+```bash
+composer validate:e2e-manifest
+```
+
+This validates manifest JSON structure, required fields, allowed roles, expected result values, labels, and assertion shapes. It cannot replace full E2E coverage because it does not bootstrap WordPress or compare the manifest to `wp_get_abilities()`.
+
+For full Docker E2E, either start Compose yourself and run:
+
+```bash
+docker compose up -d
+composer e2e
+docker compose down -v
+```
+
+Or let the E2E script manage Compose:
+
+```bash
+E2E_MANAGE_COMPOSE=1 composer e2e
+```
+
+Set `E2E_KEEP_COMPOSE=1` when you want to leave the containers running for debugging.
+
+PowerShell users can run:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/qa-local.ps1 -E2E
+```
+
+Unix, macOS, and Git Bash users can run:
+
+```bash
+scripts/qa-local.sh --e2e
+```
+
 ## PR comment coverage summary
 
 The E2E PR comment includes:


### PR DESCRIPTION
## Summary
- Add `composer qa`, `composer e2e`, manifest validation, and diff-check scripts.
- Add PowerShell and Bash local QA wrappers with optional managed Docker E2E.
- Let managed E2E startup use Docker-assigned host ports by default to avoid local port conflicts.
- Document the new local QA entry points in contributor docs, E2E docs, the PR template, and repository changelog.

## Validation
- `composer qa`
- `bash -n scripts/e2e-test.sh`
- `bash -n scripts/qa-local.sh`
- `powershell -ExecutionPolicy Bypass -File scripts\qa-local.ps1 -E2E`
- Docker E2E summary: 132 passed, 0 failed; 67/67 abilities covered