### PR TITLE
Improve local QA preflight guidance

### DIFF
--- a/.github/AUTOMATION.md
+++ b/.github/AUTOMATION.md
@@ -25,8 +25,16 @@ This repository uses GitHub Actions for two purposes:
 5. Write `e2e-artifacts/e2e-summary.json` with registered ability, covered ability, test case, and negative case counts.
 6. Validate WordPress debug log for fatal/error-level entries.
 7. Upload E2E failure artifacts when the test fails.
-8. Post truthful PR status comment from an isolated comment job, including coverage and tested dependency versions.
+8. Post truthful PR status comment from an isolated comment job, including runtime-derived run facts, ability coverage, tested dependency versions, and changed files.
 9. Always clean up Docker resources.
+
+**PR comment data sources**
+- Result and workflow URL come from the current workflow run.
+- PR head commit uses `github.event.pull_request.head.sha`; tested merge commit uses `github.sha`, which is GitHub's synthetic merge commit for pull request runs.
+- Ability coverage, manifest case totals, passed cases, failed cases, and negative permission cases come from `e2e-artifacts/e2e-summary.json`, written by `tests/e2e/ability-runner.php`.
+- WordPress, PHP, MySQL, MCP Adapter, and plugin versions are collected from the live Docker/WordPress runtime after E2E runs.
+- Changed files come from the workflow's changed-file detection job.
+- Debug log status comes from the WordPress debug log scan step.
 
 **Ability coverage contract**
 - Every new `webmastery-site-toolkit-for-mcp/*` ability must add coverage in `tests/e2e/abilities-manifest.json`.
@@ -37,7 +45,7 @@ This repository uses GitHub Actions for two purposes:
 
 **Security model**
 - E2E execution jobs run with read-only permissions.
-- PR commenting is isolated to a dedicated job with comment-only write scope.
+- PR commenting is isolated to a dedicated job with comment-only write scope and no repository checkout.
 - Actions are pinned to immutable SHAs.
 
 ### Release (`release.yml`)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
 <!-- e.g. webmastery-site-toolkit-for-mcp/list-media — leave blank for bug fixes -->
 
 ## Testing
-<!-- How did you verify this works? Include local QA commands such as composer qa, scripts/qa-local.sh --e2e, or scripts/qa-local.ps1 -E2E, plus any manual ability calls and what they returned. -->
+<!-- How did you verify this works? Include local QA commands such as composer qa, scripts/qa-local.sh --e2e, scripts/qa-local.sh --preflight-only, scripts/qa-local.ps1 -E2E, or scripts/qa-local.ps1 -PreflightOnly, plus any manual ability calls and what they returned. -->
 <!-- E2E QA tests will run automatically on push. -->
 
 ## Checklist
@@ -20,6 +20,6 @@
 - [ ] User-facing changes update relevant docs (`README.md`, `readme.txt`, `tests/e2e/README.md`, or other affected markdown)
 - [ ] Plugin-facing changes update `CHANGELOG.md` under `## Unreleased`
 - [ ] Repository, CI, contributor, GitHub platform, template, or agent workflow changes update `.github/REPOSITORY_CHANGELOG.md` under `## Unreleased`
-- [ ] Local QA checked with `composer qa` or the reason it was not run is documented above
+- [ ] Local QA checked with `composer qa` or a local QA wrapper, or the missing tool/blocker is documented above
 - [ ] WordPress.org Detailed Plugin Guidelines were considered for public-facing or release-impacting changes such as naming, readme text, privacy/external calls, licensing, bundled assets, and release packaging
 - [ ] E2E QA is passing, or failures are unrelated and explained above

--- a/.github/REPOSITORY_CHANGELOG.md
+++ b/.github/REPOSITORY_CHANGELOG.md
@@ -15,6 +15,7 @@ Plugin-facing release notes belong in `CHANGELOG.md`.
 
 ### Changed
 
+- Updated E2E PR comments to replace static success bullets with runtime-derived run facts, case pass/fail counts, debug-log status, changed files, and separate PR-head/tested-merge commit SHAs.
 - Updated E2E runner behavior so local runs can optionally manage Docker Compose startup and cleanup while preserving CI behavior.
 - Updated E2E ability manifest coverage counts and cases for bulk post operation abilities.
 - Updated release, E2E, PHPCS, Composer, and documentation automation references for the Webmastery Site Toolkit for MCP package rename.

--- a/.github/REPOSITORY_CHANGELOG.md
+++ b/.github/REPOSITORY_CHANGELOG.md
@@ -8,6 +8,7 @@ Plugin-facing release notes belong in `CHANGELOG.md`.
 
 ### Added
 
+- Added local QA preflight-only modes and clearer missing-tool guidance for PHP, Composer, Docker, and Bash prerequisites.
 - Added cross-platform local QA helper scripts, a Composer QA command, and a lightweight E2E manifest validator for contributor preflight checks.
 - Added a dedicated Coding Standards workflow that installs Composer dev dependencies and runs PHPCS on pushes, pull requests, and manual dispatches.
 - Added an E2E mu-plugin fixture for custom post type ability coverage.

--- a/.github/workflows/e2e-qa.yml
+++ b/.github/workflows/e2e-qa.yml
@@ -88,6 +88,9 @@ jobs:
       covered-abilities: ${{ steps.versions.outputs.covered-abilities }}
       test-cases: ${{ steps.versions.outputs.test-cases }}
       negative-cases: ${{ steps.versions.outputs.negative-cases }}
+      passed-cases: ${{ steps.versions.outputs.passed-cases }}
+      failed-cases: ${{ steps.versions.outputs.failed-cases }}
+      debug-log-status: ${{ steps.debug-log.outputs.status }}
     steps:
       - name: Checkout code
         uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
@@ -124,6 +127,8 @@ jobs:
           covered_abilities="$(jq -r '.covered_abilities // "unknown"' "$summary_file" 2>/dev/null || echo unknown)"
           test_cases="$(jq -r '.test_cases // "unknown"' "$summary_file" 2>/dev/null || echo unknown)"
           negative_cases="$(jq -r '.negative_cases // "unknown"' "$summary_file" 2>/dev/null || echo unknown)"
+          passed_cases="$(jq -r '.passed // "unknown"' "$summary_file" 2>/dev/null || echo unknown)"
+          failed_cases="$(jq -r '.failed // "unknown"' "$summary_file" 2>/dev/null || echo unknown)"
           {
             echo "wordpress-image=${wordpress_image:-unknown}"
             echo "wordpress-version=${wordpress_version:-unknown}"
@@ -137,13 +142,31 @@ jobs:
             echo "covered-abilities=${covered_abilities:-unknown}"
             echo "test-cases=${test_cases:-unknown}"
             echo "negative-cases=${negative_cases:-unknown}"
+            echo "passed-cases=${passed_cases:-unknown}"
+            echo "failed-cases=${failed_cases:-unknown}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Check WordPress debug log for errors
+        id: debug-log
         if: always()
+        shell: bash
         run: |
+          set -euo pipefail
           echo "=== WordPress Debug Log ==="
-          docker compose exec -T wordpress cat /var/www/html/wp-content/debug.log || true
+          if ! docker compose exec -T wordpress test -f /var/www/html/wp-content/debug.log; then
+            echo "No debug log found"
+            echo "status=no_debug_log" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          docker compose exec -T wordpress cat /var/www/html/wp-content/debug.log
+          if docker compose exec -T wordpress grep -Eiq 'fatal error|parse error|uncaught|error' /var/www/html/wp-content/debug.log; then
+            echo "status=error_entries_found" >> "$GITHUB_OUTPUT"
+            echo "Debug log contains fatal/error-level entries"
+            exit 1
+          fi
+
+          echo "status=no_error_entries" >> "$GITHUB_OUTPUT"
 
       - name: Collect E2E failure artifacts
         if: failure()
@@ -192,12 +215,45 @@ jobs:
           COVERED_ABILITIES: ${{ needs.e2e-test.outputs.covered-abilities }}
           TEST_CASES: ${{ needs.e2e-test.outputs.test-cases }}
           NEGATIVE_CASES: ${{ needs.e2e-test.outputs.negative-cases }}
+          PASSED_CASES: ${{ needs.e2e-test.outputs.passed-cases }}
+          FAILED_CASES: ${{ needs.e2e-test.outputs.failed-cases }}
+          DEBUG_LOG_STATUS: ${{ needs.e2e-test.outputs.debug-log-status }}
+          CHANGED_FILES: ${{ needs.changes.outputs.changed-files }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          HEAD_SHA: ${{ github.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          TESTED_SHA: ${{ github.sha }}
         shell: bash
         run: |
           set -euo pipefail
-          VERSIONS=$'\n\n### Tested versions\n\n'
+          status_label="$E2E_RESULT"
+          if [ "$E2E_RESULT" = "success" ]; then
+            status_label="passed"
+          fi
+
+          changed_files_count="unknown"
+          if [ -n "${CHANGED_FILES:-}" ] && [ "$CHANGED_FILES" != "manual-dispatch" ]; then
+            changed_files_count="$(printf '%s\n' "$CHANGED_FILES" | sed '/^$/d' | wc -l | tr -d ' ')"
+          elif [ "$CHANGED_FILES" = "manual-dispatch" ]; then
+            changed_files_count="manual-dispatch"
+          fi
+
+          RUN_FACTS=$'\n\n### Run facts\n\n'
+          RUN_FACTS+="- Result: ${status_label}"$'\n'
+          RUN_FACTS+="- PR head commit: ${PR_HEAD_SHA:-unknown}"$'\n'
+          RUN_FACTS+="- Tested merge commit: ${TESTED_SHA:-unknown}"$'\n'
+          RUN_FACTS+="- Changed files that triggered E2E: ${changed_files_count}"$'\n'
+          RUN_FACTS+="- WordPress debug log scan: ${DEBUG_LOG_STATUS:-unknown}"$'\n'
+          RUN_FACTS+="- Workflow run: ${RUN_URL:-unknown}"
+
+          COVERAGE=$'\n\n### Ability coverage from e2e-summary.json\n\n'
+          COVERAGE+="- Registered webmastery-site-toolkit-for-mcp abilities: ${REGISTERED_ABILITIES:-unknown}"$'\n'
+          COVERAGE+="- Manifest-covered abilities: ${COVERED_ABILITIES:-unknown}"$'\n'
+          COVERAGE+="- Manifest test cases: ${TEST_CASES:-unknown}"$'\n'
+          COVERAGE+="- Manifest cases passed: ${PASSED_CASES:-unknown}"$'\n'
+          COVERAGE+="- Manifest cases failed: ${FAILED_CASES:-unknown}"$'\n'
+          COVERAGE+="- Negative permission cases: ${NEGATIVE_CASES:-unknown}"
+
+          VERSIONS=$'\n\n### Tested runtime versions\n\n'
           VERSIONS+="- WordPress Docker image: ${WORDPRESS_IMAGE:-unknown}"$'\n'
           VERSIONS+="- WordPress core: ${WORDPRESS_VERSION:-unknown}"$'\n'
           VERSIONS+="- PHP: ${PHP_VERSION:-unknown}"$'\n'
@@ -205,20 +261,21 @@ jobs:
           VERSIONS+="- MySQL server: ${MYSQL_VERSION:-unknown}"$'\n'
           VERSIONS+="- MCP Adapter release: ${MCP_ADAPTER_RELEASE:-unknown}"$'\n'
           VERSIONS+="- MCP Adapter plugin: ${MCP_ADAPTER_VERSION:-unknown}"$'\n'
-          VERSIONS+="- Webmastery Site Toolkit for MCP: ${PLUGIN_VERSION:-unknown}"$'\n'
-          VERSIONS+="- Commit: ${HEAD_SHA:-unknown}"$'\n'
-          VERSIONS+="- Workflow run: ${RUN_URL:-unknown}"
-          COVERAGE=$'\n\n### Ability coverage\n\n'
-          COVERAGE+="- Registered webmastery-site-toolkit-for-mcp abilities: ${REGISTERED_ABILITIES:-unknown}"$'\n'
-          COVERAGE+="- Manifest-covered abilities: ${COVERED_ABILITIES:-unknown}"$'\n'
-          COVERAGE+="- Manifest test cases: ${TEST_CASES:-unknown}"$'\n'
-          COVERAGE+="- Negative permission cases: ${NEGATIVE_CASES:-unknown}"
-          if [ "$E2E_RESULT" = "success" ]; then
-            BODY=$'## E2E QA Tests Passed\n\n- Docker WordPress stack started\n- WordPress core installed before plugin activation\n- MCP Adapter installed from official WordPress release asset\n- Manifest covers every registered webmastery-site-toolkit-for-mcp ability\n- Ability execution tests passed\n- PHP syntax checks passed\n- WordPress debug log scan found no fatal/error-level entries'
+          VERSIONS+="- Webmastery Site Toolkit for MCP: ${PLUGIN_VERSION:-unknown}"
+
+          CHANGES=$'\n\n### Changed files\n\n'
+          if [ -n "${CHANGED_FILES:-}" ]; then
+            CHANGES+="$(printf '%s\n' "$CHANGED_FILES" | sed '/^$/d' | sed 's/^/- /')"
           else
-            BODY=$"## E2E QA Tests Failed\n\n- Result: ${E2E_RESULT}\n- Review this workflow run and uploaded E2E failure artifacts for the failed setup/test phase details."
+            CHANGES+="- unknown"
           fi
-          BODY+="$COVERAGE$VERSIONS"
+
+          if [ "$E2E_RESULT" = "success" ]; then
+            BODY=$'## E2E QA Tests Passed'
+          else
+            BODY=$'## E2E QA Tests Failed\n\nReview this workflow run and uploaded E2E failure artifacts for the failed setup/test phase details.'
+          fi
+          BODY+="$RUN_FACTS$COVERAGE$VERSIONS$CHANGES"
           gh api "repos/$OWNER/$REPO/issues/$ISSUE_NUMBER/comments" --method POST -f body="$BODY"
 
   skip-summary:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,14 +127,37 @@ Use the fastest command that covers your change:
 | `E2E_MANAGE_COMPOSE=1 composer e2e` | Docker WordPress E2E with automatic Compose startup and cleanup |
 | `scripts/qa-local.sh --e2e` | Unix/Git Bash wrapper for Composer QA plus managed Docker E2E |
 | `powershell -ExecutionPolicy Bypass -File scripts/qa-local.ps1 -E2E` | PowerShell wrapper for Composer QA plus managed Docker E2E |
+| `powershell -ExecutionPolicy Bypass -File scripts/qa-local.ps1 -PreflightOnly` | Windows prerequisite check without installing dependencies or running QA |
+| `scripts/qa-local.sh --preflight-only` | Unix/Git Bash prerequisite check without installing dependencies or running QA |
 
-For Windows, install PHP and Composer first, then restart your terminal so both commands are available on `PATH`. If a Windows Composer installation cannot invoke `vendor/bin/phpcs` by name, run the equivalent direct fallback:
+For Windows, install PHP and Composer first, then restart your terminal so both commands are available on `PATH`. A winget-based PHP install is acceptable when it provides PHP 8.0+:
+
+```powershell
+winget search PHP --source winget
+winget install --id PHP.PHP.8.2 --source winget
+php -v
+composer --version
+powershell -ExecutionPolicy Bypass -File scripts/qa-local.ps1 -PreflightOnly
+```
+
+If winget installs PHP but `php` is still unavailable, add the package directory that contains `php.exe` to your user `PATH`, then restart the terminal. Composer can be installed globally, or as a user-local wrapper that invokes `composer.phar` with the PHP binary.
+
+If you run the Bash wrapper from WSL, install PHP and Composer inside WSL. Windows `php.exe` and `composer.bat` may appear on WSL's `PATH`, but the Bash wrapper expects Unix `php` and `composer` commands. Use the PowerShell wrapper when validating with Windows-installed PHP and Composer.
+
+If a Windows Composer installation cannot invoke `vendor/bin/phpcs` by name, run the equivalent direct fallback:
 
 ```powershell
 php vendor\squizlabs\php_codesniffer\bin\phpcs --standard=phpcs.xml.dist
 ```
 
 The lightweight manifest validator checks JSON structure, expected fields, roles, labels, and assertion shapes. Full ability registration coverage still requires Docker E2E because registered abilities are only available inside WordPress after the plugin and MCP Adapter load.
+
+When checking GitHub Actions status from the CLI, include the PR number or branch before `--repo`:
+
+```bash
+gh pr checks 67 --repo DanielBoring/webmastery-site-toolkit-for-mcp --watch=false
+gh pr checks issue-18-content-hygiene --repo DanielBoring/webmastery-site-toolkit-for-mcp --watch
+```
 
 ---
 

--- a/scripts/qa-local.ps1
+++ b/scripts/qa-local.ps1
@@ -1,6 +1,7 @@
 param(
 	[switch] $E2E,
-	[switch] $KeepCompose
+	[switch] $KeepCompose,
+	[switch] $PreflightOnly
 )
 
 $ErrorActionPreference = 'Stop'
@@ -23,7 +24,15 @@ function Test-QACommand {
 	param([string] $Name)
 
 	if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
-		throw "Missing required command: $Name"
+		$hint = switch ($Name) {
+			'php' { 'Install PHP 8.0+ and restart the terminal so php is on PATH. On Windows, winget package PHP.PHP.8.2 is a supported option.' }
+			'composer' { 'Install Composer and restart the terminal so composer is on PATH. See CONTRIBUTING.md > Local QA commands for Windows setup notes.' }
+			'docker' { 'Install Docker Desktop and ensure docker is on PATH before running E2E.' }
+			'bash' { 'Install Git for Windows or another Bash provider before running E2E.' }
+			default { 'Install it and restart the terminal so it is available on PATH.' }
+		}
+
+		throw "Missing required command: $Name. $hint"
 	}
 }
 
@@ -31,13 +40,20 @@ Test-QACommand 'php'
 Test-QACommand 'composer'
 Test-QACommand 'git'
 
+if ($E2E) {
+	Test-QACommand 'docker'
+	Test-QACommand 'bash'
+}
+
+if ($PreflightOnly) {
+	Write-Host 'Local QA prerequisites are available.'
+	exit 0
+}
+
 Invoke-QACommand 'Install Composer dependencies' 'composer' @('install', '--no-interaction')
 Invoke-QACommand 'Run Composer QA checks' 'composer' @('qa')
 
 if ($E2E) {
-	Test-QACommand 'docker'
-	Test-QACommand 'bash'
-
 	$keepComposeValue = if ($KeepCompose) { '1' } else { '0' }
 
 	Invoke-QACommand 'Run Docker E2E QA' 'bash' @('-lc', "E2E_MANAGE_COMPOSE=1 E2E_KEEP_COMPOSE=$keepComposeValue bash scripts/e2e-test.sh")

--- a/scripts/qa-local.sh
+++ b/scripts/qa-local.sh
@@ -3,15 +3,19 @@ set -Eeuo pipefail
 
 RUN_E2E=0
 KEEP_COMPOSE=0
+PREFLIGHT_ONLY=0
 
 usage() {
 	cat <<'USAGE'
-Usage: scripts/qa-local.sh [--e2e] [--keep-compose]
+Usage: scripts/qa-local.sh [--e2e] [--keep-compose] [--preflight-only]
 
 Runs local preflight QA:
   - composer install --no-interaction
   - composer qa
   - optional Docker E2E via scripts/e2e-test.sh
+
+Options:
+  --preflight-only  check required commands and exit without running QA
 USAGE
 }
 
@@ -22,6 +26,9 @@ while [ "$#" -gt 0 ]; do
 			;;
 		--keep-compose)
 			KEEP_COMPOSE=1
+			;;
+		--preflight-only)
+			PREFLIGHT_ONLY=1
 			;;
 		-h|--help)
 			usage
@@ -38,7 +45,33 @@ done
 
 require_command() {
 	if ! command -v "$1" >/dev/null 2>&1; then
-		echo "Missing required command: $1" >&2
+		case "$1" in
+			php)
+				if command -v php.exe >/dev/null 2>&1; then
+					hint="Found Windows php.exe, but this Bash wrapper expects a Unix php command. Install PHP inside this Bash/WSL environment, or use scripts/qa-local.ps1 from PowerShell."
+				else
+					hint="Install PHP 8.0+ and restart the terminal so php is on PATH."
+				fi
+				;;
+			composer)
+				if command -v composer.bat >/dev/null 2>&1; then
+					hint="Found Windows composer.bat, but this Bash wrapper expects a Unix composer command. Install Composer inside this Bash/WSL environment, or use scripts/qa-local.ps1 from PowerShell."
+				else
+					hint="Install Composer and restart the terminal so composer is on PATH. See CONTRIBUTING.md > Local QA commands for setup notes."
+				fi
+				;;
+			docker)
+				hint="Install Docker Desktop or Docker Engine before running E2E."
+				;;
+			bash)
+				hint="Install Bash before running E2E."
+				;;
+			*)
+				hint="Install it and restart the terminal so it is available on PATH."
+				;;
+		esac
+
+		echo "Missing required command: $1. $hint" >&2
 		exit 1
 	fi
 }
@@ -52,12 +85,20 @@ require_command php
 require_command composer
 require_command git
 
+if [ "$RUN_E2E" = "1" ]; then
+	require_command docker
+	require_command bash
+fi
+
+if [ "$PREFLIGHT_ONLY" = "1" ]; then
+	echo "Local QA prerequisites are available."
+	exit 0
+fi
+
 run_step composer install --no-interaction
 run_step composer qa
 
 if [ "$RUN_E2E" = "1" ]; then
-	require_command docker
-	require_command bash
 
 	E2E_MANAGE_COMPOSE=1 E2E_KEEP_COMPOSE="$KEEP_COMPOSE" run_step bash scripts/e2e-test.sh
 fi


### PR DESCRIPTION
## Summary
- Add preflight-only modes to the PowerShell and Bash local QA wrappers
- Make missing PHP, Composer, Docker, and Bash prerequisites fail with actionable setup hints
- Document Windows PHP/Composer setup, WSL wrapper expectations, and correct `gh pr checks` usage
- Replace static E2E PR success bullets with runtime-derived run facts, coverage pass/fail counts, debug-log status, changed files, and separate PR-head/tested-merge commit SHAs
- Update automation docs and repository changelog for the repo-only workflow changes

## Validation
- `powershell -ExecutionPolicy Bypass -File scripts\qa-local.ps1 -PreflightOnly`
- `powershell -ExecutionPolicy Bypass -File scripts\qa-local.ps1`
- `composer qa`
- `git diff --check`
- PR E2E workflow completed successfully and posted a dynamic comment with run facts, 141/141 manifest cases passed, runtime versions, and changed files

## Notes
- Installed/activated local PHP 8.2 and Composer for this Windows user environment so Composer QA can run locally.
- In this shell, `bash scripts/qa-local.sh --preflight-only` correctly reports that WSL sees Windows `php.exe` and should either install Unix PHP/Composer inside WSL or use the PowerShell wrapper.