### PR TITLE
Shorten WordPress.org release description

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -9,7 +9,7 @@ License: GPL-2.0+
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Donate link: https://paypal.me/VirtuallyBoring
 
-Adds MCP-powered WordPress site abilities for posts, revisions, post meta, pages, custom post types, media, content hygiene, comments, plugins, SEO, webmaster verification signals, health, database health, performance status, backup status, security, users, and site info.
+Adds MCP-powered WordPress abilities for content, media, comments, SEO, audits, health, backups, security, users, plugins, and site info.
 
 == Description ==
 


### PR DESCRIPTION
## Summary
- Shorten the WordPress.org `readme.txt` short description so the release workflow passes the 150-character validation gate
- Keep the description aligned with the 2.3.0 ability scope while preserving the existing plugin version and changelog updates

## Testing
- composer qa
- git diff --check
- verified readme short description length is 137 characters