### PR TITLE
[codex] Harden QA and release workflows

### DIFF
--- a/.github/AUTOMATION.md
+++ b/.github/AUTOMATION.md
@@ -1,32 +1,30 @@
 # GitHub Actions Automation Guide
 
-This repository uses GitHub Actions for two purposes:
-1. Docker-based E2E QA validation.
-2. Tag-based release publishing.
+This repository uses GitHub Actions for five QA layers plus tag-based release publishing. See [`docs/qa-strategy.md`](../docs/qa-strategy.md) for the teaching-oriented strategy guide and branch-protection recommendations.
 
 ## Trigger map (event -> workflow -> behavior)
 
 | Event | Workflow file | Behavior |
 |------|------|------|
-| `pull_request` (`opened`, `synchronize`, `reopened`) | `.github/workflows/e2e-qa.yml` | Detects relevant changed files, runs E2E QA when in scope, and posts an accurate PR comment (pass/fail). |
-| `push` to `main` or `develop` | `.github/workflows/e2e-qa.yml` | Detects relevant changed files and runs E2E QA when in scope. |
-| `workflow_dispatch` | `.github/workflows/e2e-qa.yml` | Runs E2E QA on demand. |
-| `push` tag `v*` | `.github/workflows/release.yml` | Validates plugin version/release-note alignment, builds and validates release ZIP, then publishes a GitHub release. |
+| `pull_request` (`opened`, `synchronize`, `reopened`) | `.github/workflows/coding-standards.yml` | Runs Static QA on every PR. |
+| `pull_request` (`opened`, `synchronize`, `reopened`) | `.github/workflows/unit-tests.yml` | Runs PHPUnit unit tests on every PR. |
+| `pull_request` (`opened`, `synchronize`, `reopened`) | `.github/workflows/e2e-qa.yml` | Detects runtime-impacting files, then runs Ability Contract QA and Full MCP E2E QA when in scope. |
+| release-impacting `pull_request` or `workflow_dispatch` | `.github/workflows/release-package-qa.yml` | Builds and validates the release package without publishing a GitHub release. |
+| `push` to `main` or `develop` | Static, unit, and Docker QA workflows | Re-runs the appropriate checks after merge. |
+| `workflow_dispatch` | Static, unit, Docker, or release workflows | Runs the selected QA layer on demand. |
+| `push` tag `v*` | `.github/workflows/release.yml` | Runs Release Package QA, then publishes a GitHub release. |
 
 ## Workflow details
 
-### E2E QA (`e2e-qa.yml`)
+### Docker QA (`e2e-qa.yml`)
 
 **Execution flow**
-1. Detect whether changed files are in E2E scope.
-2. If in scope, start Docker stack and run `scripts/e2e-test.sh`.
-3. Run manifest-driven ability coverage from `tests/e2e/abilities-manifest.json`.
-4. Fail if a registered `webmastery-site-toolkit-for-mcp/*` ability is missing from the manifest or if the manifest references an unregistered ability.
-5. Write `e2e-artifacts/e2e-summary.json` with registered ability, covered ability, test case, and negative case counts.
-6. Validate WordPress debug log for fatal/error-level entries.
-7. Upload E2E failure artifacts when the test fails.
-8. Post truthful PR status comment from an isolated comment job, including runtime-derived run facts, ability coverage, tested dependency versions, and changed files.
-9. Always clean up Docker resources.
+1. Detect whether changed files are runtime-impacting.
+2. If in scope, run Ability Contract QA with `scripts/e2e-test.sh contract`.
+3. Run Full MCP E2E QA with `scripts/e2e-test.sh e2e`.
+4. Upload Docker/WordPress failure artifacts when either Docker lane fails.
+5. Post a PR comment from an isolated comment job with runtime-derived run facts, contract coverage, tested dependency versions, and changed files.
+6. Always clean up Docker resources.
 
 **PR comment data sources**
 - Result and workflow URL come from the current workflow run.
@@ -54,7 +52,7 @@ This repository uses GitHub Actions for two purposes:
 1. Trigger on tag push matching `v*`.
 2. Validate `tag version == plugin header version == readme stable tag`.
 3. Verify plugin release notes exist in `readme.txt` for the tagged version.
-4. Build plugin ZIP and validate required/forbidden contents.
+4. Run `scripts/release-qa.sh` to build the plugin ZIP, validate required/forbidden contents, and run WordPress Plugin Check against the built package.
 5. Fail if a release for the same tag already exists.
 6. Publish release with notes from `readme.txt`.
 
@@ -64,11 +62,12 @@ This repository uses GitHub Actions for two purposes:
 - Include `Closes #N` / `Fixes #N` / `Resolves #N` in PR body when merge should close an issue.
 - GitHub native issue closing handles closure on merge; no custom close workflow is used.
 
-## Local E2E testing
+## Local Docker QA
 
 ```bash
 docker compose up -d
-bash scripts/e2e-test.sh
+bash scripts/e2e-test.sh contract
+bash scripts/e2e-test.sh e2e
 docker compose down -v
 ```
 
@@ -76,4 +75,4 @@ The E2E bootstrap installs and activates Yoast SEO and SEOPress from WordPress.o
 
 ## Branch protection recommendation
 
-Require the E2E QA check before merging to `main`.
+Require Static QA and Unit Tests before every merge. Require Ability Contract QA and Full MCP E2E QA before merging runtime-impacting PRs.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,8 +8,8 @@
 <!-- e.g. webmastery-site-toolkit-for-mcp/list-media — leave blank for bug fixes -->
 
 ## Testing
-<!-- How did you verify this works? Include local QA commands such as composer qa, scripts/qa-local.sh --e2e, scripts/qa-local.sh --preflight-only, scripts/qa-local.ps1 -E2E, or scripts/qa-local.ps1 -PreflightOnly, plus any manual ability calls and what they returned. -->
-<!-- E2E QA tests will run automatically on push. -->
+<!-- How did you verify this works? Include local QA commands such as composer qa, scripts/qa-local.sh --contract, scripts/qa-local.sh --e2e, scripts/qa-local.ps1 -Contract, scripts/qa-local.ps1 -E2E, or scripts/qa-local.ps1 -PreflightOnly, plus any manual ability calls and what they returned. See docs/qa-strategy.md for which command fits each change type. -->
+<!-- Static QA and Unit Tests run automatically on every PR. Docker QA runs automatically for runtime-impacting changes. -->
 
 ## Checklist
 - [ ] Capability checks use the narrowest relevant WordPress capability and return/surface `WP_Error` on failure
@@ -20,6 +20,6 @@
 - [ ] User-facing changes update relevant docs (`README.md`, `readme.txt`, `tests/e2e/README.md`, or other affected markdown)
 - [ ] Plugin-facing changes update `CHANGELOG.md` under `## Unreleased`
 - [ ] Repository, CI, contributor, GitHub platform, template, or agent workflow changes update `.github/REPOSITORY_CHANGELOG.md` under `## Unreleased`
-- [ ] Local QA checked with `composer qa` or a local QA wrapper, or the missing tool/blocker is documented above
+- [ ] Local QA checked with `composer qa` and the relevant Docker/release QA wrapper from `docs/qa-strategy.md`, or the missing tool/blocker is documented above
 - [ ] WordPress.org Detailed Plugin Guidelines were considered for public-facing or release-impacting changes such as naming, readme text, privacy/external calls, licensing, bundled assets, and release packaging
 - [ ] E2E QA is passing, or failures are unrelated and explained above

--- a/.github/REPOSITORY_CHANGELOG.md
+++ b/.github/REPOSITORY_CHANGELOG.md
@@ -8,6 +8,8 @@ Plugin-facing release notes belong in `CHANGELOG.md`.
 
 ### Added
 
+- Added a five-layer QA strategy guide, PHPUnit/PHPStan QA commands, unit-test scaffolding, and separate GitHub Actions lanes for Static QA, Unit Tests, Ability Contract QA, Full MCP E2E QA, and Release Package QA.
+- Added environment-specific QA notes for GitHub Actions, Windows PowerShell, and Windows Git Bash.
 - Added secondary in-depth E2E CRUD QA that exercises real MCP Adapter HTTP JSON-RPC sessions against the default server.
 - Added E2E manifest coverage for expanded Yoast SEO metadata writes and the read-only Yoast metadata inspection ability.
 - Added E2E manifest coverage for SEOPress metadata writes and the read-only SEOPress metadata inspection ability.

--- a/.github/workflows/e2e-qa.yml
+++ b/.github/workflows/e2e-qa.yml
@@ -1,4 +1,4 @@
-name: E2E QA Testing
+name: Docker QA
 
 on:
   workflow_dispatch:
@@ -21,7 +21,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Detect relevant file changes
+      - name: Detect runtime-impacting file changes
         id: filter
         shell: bash
         run: |
@@ -52,7 +52,7 @@ jobs:
 
           printf '%s\n' "$CHANGED_FILES"
 
-          if printf '%s\n' "$CHANGED_FILES" | grep -Eq '^(\.github/workflows/e2e-qa\.yml|docker-compose\.yml|scripts/e2e-test\.sh|tests/e2e/|includes/|webmastery-site-toolkit-for-mcp\.php|readme\.txt|composer\.(json|lock)|phpcs\.xml\.dist|assets/)'; then
+          if printf '%s\n' "$CHANGED_FILES" | grep -Eq '^(\.github/workflows/|docker-compose\.yml|scripts/|tests/|includes/|webmastery-site-toolkit-for-mcp\.php|readme\.txt|composer\.(json|lock)|phpcs\.xml\.dist|phpstan\.neon\.dist|phpunit\.xml\.dist|assets/)'; then
             echo "should-run=true" >> "$GITHUB_OUTPUT"
           else
             echo "should-run=false" >> "$GITHUB_OUTPUT"
@@ -64,13 +64,13 @@ jobs:
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 
-  e2e-test:
+  ability-contract-qa:
     needs: changes
     if: needs.changes.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      COMPOSE_PROJECT_NAME: webmastery-site-toolkit-for-mcp-${{ github.event.pull_request.number || github.run_id }}
+      COMPOSE_PROJECT_NAME: webmastery-site-toolkit-for-mcp-contract-${{ github.event.pull_request.number || github.run_id }}
       MYSQL_PORT: 0
       WORDPRESS_PORT: 0
     permissions:
@@ -107,10 +107,10 @@ jobs:
           docker compose down -v --remove-orphans
           docker compose up -d
 
-      - name: Run E2E tests
-        run: bash scripts/e2e-test.sh
+      - name: Run Ability Contract QA
+        run: bash scripts/e2e-test.sh contract
 
-      - name: Collect tested versions
+      - name: Collect tested versions and contract summary
         id: versions
         if: always()
         shell: bash
@@ -158,23 +158,18 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "=== WordPress Debug Log ==="
           if ! docker compose exec -T wordpress test -f /var/www/html/wp-content/debug.log; then
-            echo "No debug log found"
             echo "status=no_debug_log" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-
           docker compose exec -T wordpress cat /var/www/html/wp-content/debug.log
           if docker compose exec -T wordpress grep -Eiq 'fatal error|parse error|uncaught|error' /var/www/html/wp-content/debug.log; then
             echo "status=error_entries_found" >> "$GITHUB_OUTPUT"
-            echo "Debug log contains fatal/error-level entries"
             exit 1
           fi
-
           echo "status=no_error_entries" >> "$GITHUB_OUTPUT"
 
-      - name: Collect E2E failure artifacts
+      - name: Collect failure artifacts
         if: failure()
         shell: bash
         run: |
@@ -184,48 +179,97 @@ jobs:
 
       - name: Clean up
         if: always()
-        run: docker compose down -v
+        run: docker compose down -v --remove-orphans
 
-      - name: Upload E2E failure artifacts
+      - name: Upload failure artifacts
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: e2e-failure-artifacts
+          name: ability-contract-failure-artifacts
+          path: e2e-artifacts/
+          if-no-files-found: ignore
+
+  full-mcp-e2e-qa:
+    needs: changes
+    if: needs.changes.outputs.should-run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      COMPOSE_PROJECT_NAME: webmastery-site-toolkit-for-mcp-e2e-${{ github.event.pull_request.number || github.run_id }}
+      MYSQL_PORT: 0
+      WORDPRESS_PORT: 0
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          fetch-depth: 1
+
+      - name: Set up Docker Compose
+        run: docker compose version
+
+      - name: Start WordPress stack
+        run: |
+          docker compose down -v --remove-orphans
+          docker compose up -d
+
+      - name: Run Full MCP E2E QA
+        run: bash scripts/e2e-test.sh e2e
+
+      - name: Collect failure artifacts
+        if: failure()
+        shell: bash
+        run: |
+          mkdir -p e2e-artifacts
+          docker compose logs --no-color > e2e-artifacts/docker-compose.log || true
+          docker compose exec -T wordpress cat /var/www/html/wp-content/debug.log > e2e-artifacts/wordpress-debug.log 2>/dev/null || true
+
+      - name: Clean up
+        if: always()
+        run: docker compose down -v --remove-orphans
+
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: full-mcp-e2e-failure-artifacts
           path: e2e-artifacts/
           if-no-files-found: ignore
 
   comment-pr:
-    needs: [changes, e2e-test]
+    needs: [changes, ability-contract-qa, full-mcp-e2e-qa]
     if: github.event_name == 'pull_request' && needs.changes.outputs.should-run == 'true' && always()
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
       contents: read
     steps:
-      - name: Comment E2E result on PR
+      - name: Comment Docker QA result on PR
         env:
           GH_TOKEN: ${{ github.token }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           ISSUE_NUMBER: ${{ github.event.pull_request.number }}
-          E2E_RESULT: ${{ needs.e2e-test.result }}
-          WORDPRESS_IMAGE: ${{ needs.e2e-test.outputs.wordpress-image }}
-          WORDPRESS_VERSION: ${{ needs.e2e-test.outputs.wordpress-version }}
-          PHP_VERSION: ${{ needs.e2e-test.outputs.php-version }}
-          MYSQL_IMAGE: ${{ needs.e2e-test.outputs.mysql-image }}
-          MYSQL_VERSION: ${{ needs.e2e-test.outputs.mysql-version }}
-          MCP_ADAPTER_RELEASE: ${{ needs.e2e-test.outputs.mcp-adapter-release }}
-          MCP_ADAPTER_VERSION: ${{ needs.e2e-test.outputs.mcp-adapter-version }}
-          YOAST_VERSION: ${{ needs.e2e-test.outputs.yoast-version }}
-          SEOPRESS_VERSION: ${{ needs.e2e-test.outputs.seopress-version }}
-          PLUGIN_VERSION: ${{ needs.e2e-test.outputs.plugin-version }}
-          REGISTERED_ABILITIES: ${{ needs.e2e-test.outputs.registered-abilities }}
-          COVERED_ABILITIES: ${{ needs.e2e-test.outputs.covered-abilities }}
-          TEST_CASES: ${{ needs.e2e-test.outputs.test-cases }}
-          NEGATIVE_CASES: ${{ needs.e2e-test.outputs.negative-cases }}
-          PASSED_CASES: ${{ needs.e2e-test.outputs.passed-cases }}
-          FAILED_CASES: ${{ needs.e2e-test.outputs.failed-cases }}
-          DEBUG_LOG_STATUS: ${{ needs.e2e-test.outputs.debug-log-status }}
+          CONTRACT_RESULT: ${{ needs.ability-contract-qa.result }}
+          E2E_RESULT: ${{ needs.full-mcp-e2e-qa.result }}
+          REGISTERED_ABILITIES: ${{ needs.ability-contract-qa.outputs.registered-abilities }}
+          COVERED_ABILITIES: ${{ needs.ability-contract-qa.outputs.covered-abilities }}
+          TEST_CASES: ${{ needs.ability-contract-qa.outputs.test-cases }}
+          NEGATIVE_CASES: ${{ needs.ability-contract-qa.outputs.negative-cases }}
+          PASSED_CASES: ${{ needs.ability-contract-qa.outputs.passed-cases }}
+          FAILED_CASES: ${{ needs.ability-contract-qa.outputs.failed-cases }}
+          DEBUG_LOG_STATUS: ${{ needs.ability-contract-qa.outputs.debug-log-status }}
+          WORDPRESS_IMAGE: ${{ needs.ability-contract-qa.outputs.wordpress-image }}
+          WORDPRESS_VERSION: ${{ needs.ability-contract-qa.outputs.wordpress-version }}
+          PHP_VERSION: ${{ needs.ability-contract-qa.outputs.php-version }}
+          MYSQL_IMAGE: ${{ needs.ability-contract-qa.outputs.mysql-image }}
+          MYSQL_VERSION: ${{ needs.ability-contract-qa.outputs.mysql-version }}
+          MCP_ADAPTER_RELEASE: ${{ needs.ability-contract-qa.outputs.mcp-adapter-release }}
+          MCP_ADAPTER_VERSION: ${{ needs.ability-contract-qa.outputs.mcp-adapter-version }}
+          YOAST_VERSION: ${{ needs.ability-contract-qa.outputs.yoast-version }}
+          SEOPRESS_VERSION: ${{ needs.ability-contract-qa.outputs.seopress-version }}
+          PLUGIN_VERSION: ${{ needs.ability-contract-qa.outputs.plugin-version }}
           CHANGED_FILES: ${{ needs.changes.outputs.changed-files }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -233,59 +277,37 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          status_label="$E2E_RESULT"
-          if [ "$E2E_RESULT" = "success" ]; then
-            status_label="passed"
-          fi
-
-          changed_files_count="unknown"
-          if [ -n "${CHANGED_FILES:-}" ] && [ "$CHANGED_FILES" != "manual-dispatch" ]; then
-            changed_files_count="$(printf '%s\n' "$CHANGED_FILES" | sed '/^$/d' | wc -l | tr -d ' ')"
-          elif [ "$CHANGED_FILES" = "manual-dispatch" ]; then
-            changed_files_count="manual-dispatch"
-          fi
-
-          RUN_FACTS=$'\n\n### Run facts\n\n'
-          RUN_FACTS+="- Result: ${status_label}"$'\n'
-          RUN_FACTS+="- PR head commit: ${PR_HEAD_SHA:-unknown}"$'\n'
-          RUN_FACTS+="- Tested merge commit: ${TESTED_SHA:-unknown}"$'\n'
-          RUN_FACTS+="- Changed files that triggered E2E: ${changed_files_count}"$'\n'
-          RUN_FACTS+="- WordPress debug log scan: ${DEBUG_LOG_STATUS:-unknown}"$'\n'
-          RUN_FACTS+="- Workflow run: ${RUN_URL:-unknown}"
-
-          COVERAGE=$'\n\n### Ability coverage from e2e-summary.json\n\n'
-          COVERAGE+="- Registered webmastery-site-toolkit-for-mcp abilities: ${REGISTERED_ABILITIES:-unknown}"$'\n'
-          COVERAGE+="- Manifest-covered abilities: ${COVERED_ABILITIES:-unknown}"$'\n'
-          COVERAGE+="- Manifest test cases: ${TEST_CASES:-unknown}"$'\n'
-          COVERAGE+="- Manifest cases passed: ${PASSED_CASES:-unknown}"$'\n'
-          COVERAGE+="- Manifest cases failed: ${FAILED_CASES:-unknown}"$'\n'
-          COVERAGE+="- Negative permission cases: ${NEGATIVE_CASES:-unknown}"
-
-          VERSIONS=$'\n\n### Tested runtime versions\n\n'
-          VERSIONS+="- WordPress Docker image: ${WORDPRESS_IMAGE:-unknown}"$'\n'
-          VERSIONS+="- WordPress core: ${WORDPRESS_VERSION:-unknown}"$'\n'
-          VERSIONS+="- PHP: ${PHP_VERSION:-unknown}"$'\n'
-          VERSIONS+="- MySQL Docker image: ${MYSQL_IMAGE:-unknown}"$'\n'
-          VERSIONS+="- MySQL server: ${MYSQL_VERSION:-unknown}"$'\n'
-          VERSIONS+="- MCP Adapter release: ${MCP_ADAPTER_RELEASE:-unknown}"$'\n'
-          VERSIONS+="- MCP Adapter plugin: ${MCP_ADAPTER_VERSION:-unknown}"$'\n'
-          VERSIONS+="- Yoast SEO plugin: ${YOAST_VERSION:-unknown}"$'\n'
-          VERSIONS+="- SEOPress plugin: ${SEOPRESS_VERSION:-unknown}"$'\n'
-          VERSIONS+="- Webmastery Site Toolkit for MCP: ${PLUGIN_VERSION:-unknown}"
-
-          CHANGES=$'\n\n### Changed files\n\n'
+          BODY=$'## Docker QA Summary\n\n'
+          BODY+="- Ability Contract QA: ${CONTRACT_RESULT:-unknown}"$'\n'
+          BODY+="- Full MCP E2E QA: ${E2E_RESULT:-unknown}"$'\n'
+          BODY+="- PR head commit: ${PR_HEAD_SHA:-unknown}"$'\n'
+          BODY+="- Tested merge commit: ${TESTED_SHA:-unknown}"$'\n'
+          BODY+="- WordPress debug log scan: ${DEBUG_LOG_STATUS:-unknown}"$'\n'
+          BODY+="- Workflow run: ${RUN_URL:-unknown}"$'\n'
+          BODY+=$'\n### Ability Contract Coverage\n\n'
+          BODY+="- Registered webmastery-site-toolkit-for-mcp abilities: ${REGISTERED_ABILITIES:-unknown}"$'\n'
+          BODY+="- Manifest-covered abilities: ${COVERED_ABILITIES:-unknown}"$'\n'
+          BODY+="- Manifest test cases: ${TEST_CASES:-unknown}"$'\n'
+          BODY+="- Manifest cases passed: ${PASSED_CASES:-unknown}"$'\n'
+          BODY+="- Manifest cases failed: ${FAILED_CASES:-unknown}"$'\n'
+          BODY+="- Negative permission cases: ${NEGATIVE_CASES:-unknown}"$'\n'
+          BODY+=$'\n### Tested Runtime\n\n'
+          BODY+="- WordPress Docker image: ${WORDPRESS_IMAGE:-unknown}"$'\n'
+          BODY+="- WordPress core: ${WORDPRESS_VERSION:-unknown}"$'\n'
+          BODY+="- PHP: ${PHP_VERSION:-unknown}"$'\n'
+          BODY+="- MySQL Docker image: ${MYSQL_IMAGE:-unknown}"$'\n'
+          BODY+="- MySQL server: ${MYSQL_VERSION:-unknown}"$'\n'
+          BODY+="- MCP Adapter release: ${MCP_ADAPTER_RELEASE:-unknown}"$'\n'
+          BODY+="- MCP Adapter plugin: ${MCP_ADAPTER_VERSION:-unknown}"$'\n'
+          BODY+="- Yoast SEO plugin: ${YOAST_VERSION:-unknown}"$'\n'
+          BODY+="- SEOPress plugin: ${SEOPRESS_VERSION:-unknown}"$'\n'
+          BODY+="- Webmastery Site Toolkit for MCP: ${PLUGIN_VERSION:-unknown}"$'\n'
+          BODY+=$'\n### Changed Files\n\n'
           if [ -n "${CHANGED_FILES:-}" ]; then
-            CHANGES+="$(printf '%s\n' "$CHANGED_FILES" | sed '/^$/d' | sed 's/^/- /')"
+            BODY+="$(printf '%s\n' "$CHANGED_FILES" | sed '/^$/d' | sed 's/^/- /')"
           else
-            CHANGES+="- unknown"
+            BODY+="- unknown"
           fi
-
-          if [ "$E2E_RESULT" = "success" ]; then
-            BODY=$'## E2E QA Tests Passed'
-          else
-            BODY=$'## E2E QA Tests Failed\n\nReview this workflow run and uploaded E2E failure artifacts for the failed setup/test phase details.'
-          fi
-          BODY+="$RUN_FACTS$COVERAGE$VERSIONS$CHANGES"
           gh api "repos/$OWNER/$REPO/issues/$ISSUE_NUMBER/comments" --method POST -f body="$BODY"
 
   skip-summary:
@@ -295,8 +317,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Report skipped run
+      - name: Report skipped Docker QA
         run: |
-          echo "E2E QA skipped: no relevant files changed."
+          echo "Docker QA skipped: no runtime-impacting files changed."
           echo "Changed files:"
           echo "${{ needs.changes.outputs.changed-files }}"

--- a/.github/workflows/release-package-qa.yml
+++ b/.github/workflows/release-package-qa.yml
@@ -1,0 +1,38 @@
+name: Release Package QA
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - '.github/workflows/release.yml'
+      - '.github/workflows/release-package-qa.yml'
+      - 'scripts/build-release.sh'
+      - 'scripts/release-qa.sh'
+      - 'scripts/validate-release-package.php'
+      - 'webmastery-site-toolkit-for-mcp.php'
+      - 'readme.txt'
+      - 'CHANGELOG.md'
+      - 'LICENSE'
+
+jobs:
+  release-package-qa:
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          fetch-depth: 1
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # 2.35.5
+        with:
+          php-version: '8.0'
+          coverage: none
+
+      - name: Run Release Package QA
+        run: bash scripts/release-qa.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,12 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Set up PHP
+        uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # 2.35.5
+        with:
+          php-version: '8.0'
+          coverage: none
+
       - name: Validate release inputs
         id: validate
         shell: bash
@@ -72,33 +78,8 @@ jobs:
           echo "version=$TAG_VERSION" >> "$GITHUB_OUTPUT"
           echo "notes-file=$NOTES_FILE" >> "$GITHUB_OUTPUT"
 
-      - name: Build plugin zip
-        shell: bash
-        run: |
-          set -euo pipefail
-          PACKAGE_DIR="build/webmastery-site-toolkit-for-mcp"
-          rm -rf "$PACKAGE_DIR"
-          mkdir -p "$PACKAGE_DIR"
-          rsync -r webmastery-site-toolkit-for-mcp.php readme.txt LICENSE includes "$PACKAGE_DIR/"
-          cd build
-          zip -r ../webmastery-site-toolkit-for-mcp-${{ steps.validate.outputs.version }}.zip webmastery-site-toolkit-for-mcp/
-
-      - name: Validate built artifact contents
-        shell: bash
-        run: |
-          set -euo pipefail
-          ZIP_FILE="webmastery-site-toolkit-for-mcp-${{ steps.validate.outputs.version }}.zip"
-          if [ ! -s "$ZIP_FILE" ]; then
-            echo "Missing or empty release artifact: $ZIP_FILE" >&2
-            exit 1
-          fi
-          unzip -l "$ZIP_FILE" > build/zip-listing.txt
-          grep -q 'webmastery-site-toolkit-for-mcp/webmastery-site-toolkit-for-mcp.php' build/zip-listing.txt
-          grep -q 'webmastery-site-toolkit-for-mcp/includes/' build/zip-listing.txt
-          if grep -E 'webmastery-site-toolkit-for-mcp/(\.git|\.github|assets|build|e2e-artifacts|scripts|tests|vendor)/|webmastery-site-toolkit-for-mcp/(BACKLOG|CHANGELOG|CONTRIBUTING|README)\.md|webmastery-site-toolkit-for-mcp/(composer\.(json|lock)|docker-compose\.yml|phpcs\.xml\.dist|\.gitattributes|\.gitignore)' build/zip-listing.txt; then
-            echo "Release artifact contains development, CI, test, or repository-only files" >&2
-            exit 1
-          fi
+      - name: Run Release Package QA
+        run: bash scripts/release-qa.sh "${{ steps.validate.outputs.version }}"
 
       - name: Create GitHub Release
         env:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,4 +1,4 @@
-name: Static QA
+name: Unit Tests
 
 on:
   workflow_dispatch:
@@ -8,7 +8,7 @@ on:
     branches: [main, develop]
 
 jobs:
-  static-qa:
+  unit-tests:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -42,5 +42,5 @@ jobs:
       - name: Install Composer dependencies
         run: composer install --no-interaction --prefer-dist --no-progress
 
-      - name: Run Static QA
-        run: composer qa:static
+      - name: Run Unit Tests
+        run: composer qa:unit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ composer install
 composer qa
 ```
 
-`composer qa` runs WordPress Coding Standards, the lightweight E2E manifest validator, and `git diff --check`.
+`composer qa` runs the normal fast pre-PR checks: Static QA plus Unit Tests. See [`docs/qa-strategy.md`](docs/qa-strategy.md) for the full QA posture, including when to run Ability Contract QA, Full MCP E2E QA, and Release Package QA.
 
 ---
 
@@ -120,13 +120,24 @@ Set `annotations` accurately — `readonly: true` for read-only abilities, `dest
 
 Use the fastest command that covers your change:
 
+Environment-specific notes for GitHub Actions, Windows PowerShell, and Windows Git Bash live in [`docs/qa-strategy.md`](docs/qa-strategy.md#environment-notes).
+
 | Command | What it runs |
 | --- | --- |
-| `composer qa` | PHPCS, lightweight E2E manifest validation, and `git diff --check` |
-| `composer e2e` | Docker WordPress E2E against an already-running Compose stack |
-| `E2E_MANAGE_COMPOSE=1 composer e2e` | Docker WordPress E2E with automatic Compose startup and cleanup |
-| `scripts/qa-local.sh --e2e` | Unix/Git Bash wrapper for Composer QA plus managed Docker E2E |
-| `powershell -ExecutionPolicy Bypass -File scripts/qa-local.ps1 -E2E` | PowerShell wrapper for Composer QA plus managed Docker E2E |
+| `composer qa` | Fast local default: Static QA plus Unit Tests |
+| `composer qa:static` | PHP lint, PHPCS, PHPStan, Composer audit, manifest structure validation, and `git diff --check` |
+| `composer qa:unit` | PHPUnit unit tests |
+| `composer qa:contract` | Docker Ability Contract QA against an already-running Compose stack |
+| `composer qa:e2e` | Docker Full MCP E2E QA against an already-running Compose stack |
+| `composer qa:release` | Release Package QA, including built package validation and WordPress Plugin Check |
+| `E2E_MANAGE_COMPOSE=1 composer qa:contract` | Ability Contract QA with automatic Compose startup and cleanup |
+| `E2E_MANAGE_COMPOSE=1 composer qa:e2e` | Full MCP E2E QA with automatic Compose startup and cleanup |
+| `scripts/qa-local.sh --contract` | Unix/Git Bash wrapper for Composer QA plus managed Ability Contract QA |
+| `scripts/qa-local.sh --e2e` | Unix/Git Bash wrapper for Composer QA plus managed Full MCP E2E QA |
+| `scripts/qa-local.sh --release` | Unix/Git Bash wrapper for Composer QA plus Release Package QA |
+| `powershell -ExecutionPolicy Bypass -File scripts/qa-local.ps1 -Contract` | PowerShell wrapper for Composer QA plus managed Ability Contract QA |
+| `powershell -ExecutionPolicy Bypass -File scripts/qa-local.ps1 -E2E` | PowerShell wrapper for Composer QA plus managed Full MCP E2E QA |
+| `powershell -ExecutionPolicy Bypass -File scripts/qa-local.ps1 -Release` | PowerShell wrapper for Composer QA plus Release Package QA |
 | `powershell -ExecutionPolicy Bypass -File scripts/qa-local.ps1 -PreflightOnly` | Windows prerequisite check without installing dependencies or running QA |
 | `scripts/qa-local.sh --preflight-only` | Unix/Git Bash prerequisite check without installing dependencies or running QA |
 
@@ -150,7 +161,7 @@ If a Windows Composer installation cannot invoke `vendor/bin/phpcs` by name, run
 php vendor\squizlabs\php_codesniffer\bin\phpcs --standard=phpcs.xml.dist
 ```
 
-The lightweight manifest validator checks JSON structure, expected fields, roles, labels, and assertion shapes. Full ability registration coverage still requires Docker E2E because registered abilities are only available inside WordPress after the plugin and MCP Adapter load.
+The lightweight manifest validator checks JSON structure, expected fields, roles, labels, and assertion shapes. Full ability registration coverage still requires Ability Contract QA because registered abilities are only available inside WordPress after the plugin and MCP Adapter load.
 
 When checking GitHub Actions status from the CLI, include the PR number or branch before `--repo`:
 

--- a/README.md
+++ b/README.md
@@ -17,144 +17,78 @@
     </a>
   </h2>
 
-[Quickstart](#quickstart) • [Abilities](#abilities) • [Requirements](#requirements) • [Installation](#installation) • [Verification](#verification) • [Security](#security) • [Full docs ↗](https://www.virtuallyboring.com/webmastery-site-toolkit-for-mcp/)
+[Quickstart](#quickstart) | [Abilities](#abilities) | [Requirements](#requirements) | [Connect](#connect-your-mcp-client) | [Verify](#verify) | [Security](#security) | [Full docs](https://www.virtuallyboring.com/webmastery-site-toolkit-for-mcp/)
 
 </div>
 
-**Webmastery Site Toolkit for MCP** is a WordPress plugin that lets an AI agent manage your site over MCP — posts, revisions, post meta, pages, public custom post types, media, content hygiene diagnostics, comments, taxonomy, plugins, Yoast SEO and SEOPress checks/metadata, webmaster verification signals, site health, database health, performance status, backup status, security audits, user lookup, and non-sensitive site introspection. It works with the official [MCP Adapter](https://github.com/WordPress/mcp-adapter) plugin, which provides the transport layer while this plugin registers the abilities an agent can call.
+**Webmastery Site Toolkit for MCP** is a WordPress plugin that adds MCP-powered abilities for AI agents and MCP clients. It works with the official [MCP Adapter](https://github.com/WordPress/mcp-adapter): the adapter provides the transport layer, and this plugin registers the WordPress abilities an agent can call.
 
-**Use it if you want to:**
+Use it to let an agent draft or update content, manage media and comments, inspect site health, review SEO metadata, audit plugins and users, and gather safe site context without handing your personal admin account to the agent.
 
-- Have an AI agent draft, update, or publish posts and pages
-- Ask an AI to audit your site's security or health posture
-- Bring SEO analysis into your content workflow
-
-Without this plugin, the MCP Adapter exposes only its 3 meta/discovery abilities — no content tools. With it, your agent gets full editorial access.
+> This README describes the current GitHub repo, including unreleased `main` branch work. The latest stable plugin header and WordPress.org `readme.txt` stable tag remain `2.3.0`; see [CHANGELOG.md](CHANGELOG.md) for what is released versus unreleased.
 
 <table>
 <tr><td align="center"><strong>Without this plugin</strong><br/><img src="assets/before.png" alt="Before"></td>
 <td align="center"><strong>With this plugin</strong><br/><img src="assets/after.png" alt="After"></td></tr>
 </table>
 
-> 📖 **Full reference** — the complete ability tables, architecture diagram, and extended security notes live on the project page: **[virtuallyboring.com/webmastery-site-toolkit-for-mcp](https://www.virtuallyboring.com/webmastery-site-toolkit-for-mcp/)**.
-
----
-
 ## Quickstart
 
-1. **Install the MCP Adapter** — download the [latest release zip](https://github.com/WordPress/mcp-adapter/releases/latest) → WP Admin → Plugins → Add New → Upload Plugin → Install & Activate.
-2. **Install this plugin** — download the [latest release zip](https://github.com/DanielBoring/webmastery-site-toolkit-for-mcp/releases/latest) → upload and activate the same way.
-3. **Create a dedicated Editor user** — WP Admin → Users → Add New → set Role to **Editor**.
-4. **Create an application password** — edit that user → Application Passwords → add a name → copy the generated password.
-5. **Connect your MCP client** — point `@automattic/mcp-wordpress-remote` at your site. See [Installation → Connect your MCP client](#5-connect-your-mcp-client) for the config for each client.
-6. **Verify** — ask your agent to call `mcp-adapter-discover-abilities`; you should see this plugin's abilities appear.
+1. Install and activate the [MCP Adapter](https://github.com/WordPress/mcp-adapter) plugin.
+2. Install and activate **Webmastery Site Toolkit for MCP** from the [latest GitHub release](https://github.com/DanielBoring/webmastery-site-toolkit-for-mcp/releases/latest).
+3. Create a dedicated WordPress user for the agent. Use **Editor** for normal content work.
+4. Create an application password for that user.
+5. Configure your MCP client with `@automattic/mcp-wordpress-remote`.
+6. Ask the client to call `mcp-adapter-discover-abilities`.
 
----
+The complete setup guide, client-specific examples, and full ability tables live on the [project documentation page](https://www.virtuallyboring.com/webmastery-site-toolkit-for-mcp/).
 
 ## Abilities
 
-Every ability enforces a WordPress capability check, so the tools an agent can call always reflect what its account is actually allowed to do. Pick the service-account role that matches the work.
+Every ability uses WordPress capability checks. An Editor account can handle day-to-day editorial workflows; Administrator-only abilities are intentionally separate because they expose site configuration, installed plugin metadata, or account audit details.
 
-| Category                  | Abilities | Typical min. role        |
-| ------------------------- | --------- | ------------------------ |
-| Posts                     | 9         | Author                   |
-| Revisions                 | 2         | Editor                   |
-| Post meta                 | 3         | Author → Editor          |
-| Pages                     | 6         | Editor                   |
-| Custom post types         | 1 + 5 per eligible CPT | CPT capability map |
-| Content blocks            | 2         | Author → Editor          |
-| Featured images           | 2         | Author → Editor          |
-| Taxonomy                  | 10        | Subscriber → Editor      |
-| Comments                  | 6         | Editor                   |
-| Media                     | 5         | Author                   |
-| Content hygiene           | 3         | Author → Editor          |
-| Users                     | 3         | Administrator            |
-| Site introspection        | 3         | Subscriber               |
-| Plugins                   | 4         | Administrator            |
-| Site health & security    | 5         | Administrator            |
-| SEO & webmaster signals   | 7         | Subscriber → Administrator |
+| Area | What the agent can do | Typical role |
+| --- | --- | --- |
+| Posts and pages | Create, list, read, update, restore, trash, bulk publish, bulk trash, and patch targeted content | Author or Editor |
+| Blocks and revisions | Inspect Gutenberg block paths/hashes, replace one block, list revisions, restore a revision | Author or Editor |
+| Post meta | Read, update, and delete safe custom fields; write supported Yoast SEO and SEOPress metadata | Author or Editor |
+| Custom post types | Discover eligible public CPTs and generate list/get/create/update/delete abilities | CPT capability map |
+| Taxonomy | List, get, create, update, and delete categories and tags | Subscriber to Editor |
+| Comments | List, reply, update, approve, hold, trash, or mark spam | Editor |
+| Media | List, inspect, update, upload public image URLs, set featured images, and delete media | Author or Editor |
+| Content hygiene | Find orphaned media, posts/pages missing featured images, and stuck scheduled posts | Author or Editor |
+| Site info | Return safe public site, current-user, and environment context | Subscriber |
+| SEO and webmaster signals | Analyze content, inspect Yoast/SEOPress metadata, read Yoast scores, and check public Google/Bing proof | Author to Administrator |
+| Plugins, users, health, security, performance, backups, database | Audit or manage sensitive site areas with explicit admin capabilities | Administrator |
 
-**Editor** is the recommended default for content workflows. User lookup, user access audits, plugin management/auditing, and site-audit abilities need Administrator capabilities — use a separate Administrator service account for those.
-
-Post and page listings include the numeric author ID plus `author_name` and `author_login`, so agents can show human-readable bylines without an extra user lookup. Bulk post operations can move multiple posts to trash with `bulk-trash-posts` (`delete_posts`) or publish multiple draft posts with `bulk-publish-posts` (`edit_posts`), returning per-ID success and failure summaries instead of stopping at the first problem. Revision abilities can list saved revisions for posts and pages and restore a post or page to a specific revision; both require `edit_posts` plus object-level edit access to the target content. Taxonomy abilities can list, get, create, update, and delete categories and tags; reads require `read`, while writes require `manage_categories`. Comment abilities can list and moderate comments, create threaded replies as the authenticated user when the account can edit the related post, and update comment content with optional `approve`, `hold`, `spam`, or `trash` moderation. User access auditing requires `edit_users` and returns administrator accounts, default `admin` username detection, administrator application passwords, warnings, and metadata that states whether application password collection was skipped. Site introspection abilities require `read` and return stable, non-sensitive schemas: `get-site-info` returns public site metadata, active theme name/version, deterministic timezone fallback (`UTC±HH:MM` when no timezone string is configured), multisite status, and permalink structure; `get-user-info` returns the current user's profile, roles, and a fixed capability summary; `get-environment-info` returns only PHP version, database server version, WordPress environment type, and locale. Post and page body edits can use `list-content-blocks` to inspect block paths and hashes, then `patch-content-block` to replace one exact Gutenberg block by path or unique hash. `patch-post-content` remains available for heading-section edits and strict exact-match replacement. Ambiguous, missing, or stale targets fail instead of guessing.
-
-`create-post`, `create-page`, `update-post`, and `update-page` can write REST-registered post meta plus supported Yoast SEO and SEOPress protected keys. First-class Yoast inputs cover title, meta description, focus keyphrase, canonical URL, breadcrumb title, Schema.org page/article types, Open Graph title/description/image, Twitter title/description/image, primary category, and robots noindex/nofollow/advanced directives. First-class SEOPress inputs cover title, meta description, target keywords, canonical URL, Open Graph title/description/image, Twitter/X title/description/image, primary category, robots noindex/nofollow/noimageindex/noarchive/nosnippet directives, and breadcrumb title. Unsupported protected or unregistered meta keys return a `meta_write_failed` response with `data.meta.not_written` instead of being silently ignored. Dedicated post meta abilities can read, update, or delete one post's unprotected meta keys, plus explicitly allowlisted protected keys, after an object-level `edit_post` check.
-
-Yoast-specific inputs only write `_yoast_wpseo_*` keys, and SEOPress-specific inputs only write `_seopress_*` keys. The plugin supports both SEO providers side by side without translating or overwriting the other provider's metadata, and E2E coverage verifies both write paths.
-
-`list-post-types` discovers eligible custom post types where `public = true`, `_builtin = false`, and `show_ui = true`. Each eligible CPT gets deterministic ability names in the form `list-cpt-{post-type}`, `get-cpt-{post-type}`, `create-cpt-{post-type}`, `update-cpt-{post-type}`, and `delete-cpt-{post-type}`; naming collisions append a stable short hash. CPT CRUD abilities use the post type's own capability map, including object-level `read_post`, `edit_post`, and `delete_post` checks. CPT taxonomy metadata is returned by discovery, and create/update calls can assign terms through `taxonomy_terms` when the account has the taxonomy's `assign_terms` capability.
-
-`get-seo-scores` and `get-readability-scores` return Yoast SEO and readability score meta for posts and pages with stable pagination, optional `post_type`, `status`, and `modified_after` filters, and newest-modified-first ordering. Missing score meta is returned as `null`; when Yoast SEO is not active, the abilities return an empty result with an explanatory note. `get-yoast-metadata` inspects stored Yoast metadata for a post or page, including canonical, breadcrumb, Schema.org, Open Graph, Twitter, inclusive-language score, primary category, robots directives, and generated Yoast head output when Yoast exposes it through REST. `get-seopress-metadata` inspects stored SEOPress title, description, target keywords, canonical, Open Graph, Twitter/X, primary category, robots, breadcrumb, News sitemap exclusion, and Video sitemap exclusion metadata for a post or page.
-
-`webmaster-verification-status` requires only `read` and checks public Google/Bing webmaster proof: Google Site Kit installed/active status, rendered homepage verification meta tags, `/BingSiteAuth.xml`, visible DNS TXT verification records when PHP can read them, `robots.txt` sitemap declarations, and same-host sitemap reachability. Results use `pass`, `warn`, and `unknown`; actual Google Search Console or Bing Webmaster Tools account verification is always reported as `unknown` because confirming it would require OAuth/API credentials and a separate security model.
-
-Content hygiene diagnostics are read-only audit tools for common editorial cleanup work: `list-orphaned-media` finds unattached media that is not used as a featured image or referenced in post content (`upload_files`), `list-posts-no-featured-image` finds published posts or pages without `_thumbnail_id` (`edit_posts`, plus `edit_pages` for pages), and `list-stuck-scheduled` finds scheduled posts whose publish time is already in the past (`edit_posts`). These abilities return empty `items` arrays when no matching problems are found.
-
-`upload-image` sideloads a public HTTP/HTTPS image URL into the media library with the same normalized media response shape as other media abilities. It requires `upload_files`, rejects local/private URL targets, enforces the site's upload size and allowed image MIME types, can write title/alt/caption metadata, and can attach the image to a post or page and set it as featured when the account can edit that target.
-
-`database-health` requires `manage_options` and returns read-only database bloat indicators for administrators: post revision count and revision-limit status, orphaned post meta count, expired transient count, autoloaded option size with a 900 KB threshold flag, and per-table row/data/index size details from `information_schema`. `performance-status` also requires `manage_options` and reports caching/performance configuration: external object cache status, `object-cache.php` and `advanced-cache.php` drop-in presence, active known page-cache plugins, `WP_MEMORY_LIMIT` versus PHP `memory_limit`, `WP_POST_REVISIONS`, autosave interval, and `CONCATENATE_SCRIPTS`. `backup-status` requires `manage_options` and detects active known backup plugins including UpdraftPlus, BackWPup, Duplicator, All-in-One WP Migration, BlogVault, WPvivid, Jetpack/VaultPress, and ManageWP Worker. It returns accessible last-backup and schedule details for UpdraftPlus, last-backup details for BackWPup, and a warning when no known backup plugin is active.
-
-`plugin-audit` requires `activate_plugins` and returns a read-only security and maintenance audit of installed plugins using local plugin metadata and WordPress core's cached update transient. It reports inactive plugins, cached updates and new versions, tested-up-to and minimum WordPress version metadata, potential abandonment when tested compatibility is at least two WordPress release lines behind the current site version, file-modification-age proxy days, and critical updates when the cached update response explicitly flags a security update.
-
-👉 **[See the full ability reference](https://www.virtuallyboring.com/webmastery-site-toolkit-for-mcp/#available-abilities)** for every ability, its description, required capability, and minimum role.
-
----
+For the exact ability names, input behavior, and required capabilities, use the [full ability reference](https://www.virtuallyboring.com/webmastery-site-toolkit-for-mcp/#available-abilities).
 
 ## Requirements
 
-| Requirement                                                    | Version                                                                                                          |
-| -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| WordPress                                                      | 6.9+                                                                                                             |
-| PHP                                                            | 8.0+                                                                                                             |
-| [MCP Adapter plugin](https://github.com/WordPress/mcp-adapter) | Latest                                                                                                           |
-| [Yoast SEO](https://wordpress.org/plugins/wordpress-seo/)      | Optional — structural SEO checks work without it; Yoast metadata, sitemap, and score checks require it |
-| [SEOPress](https://wordpress.org/plugins/wp-seopress/)         | Optional — structural SEO checks work without it; SEOPress metadata inspection and SEOPress-specific writes require it |
+| Requirement | Version |
+| --- | --- |
+| WordPress | 6.9+ |
+| PHP | 8.0+ |
+| [MCP Adapter](https://github.com/WordPress/mcp-adapter) | Latest |
+| [Yoast SEO](https://wordpress.org/plugins/wordpress-seo/) | Optional |
+| [SEOPress](https://wordpress.org/plugins/wp-seopress/) | Optional |
 
-> **Self-hosted WordPress only.** Both this plugin and the MCP Adapter require an install where custom plugins can be added — self-hosted WordPress or a managed host (WP Engine, Kinsta, Flywheel, etc.). They are not compatible with WordPress.com Free, Personal, or Premium plans.
+Self-hosted WordPress is required. This works on WordPress installs where custom plugins can be added, including most managed hosts. It does not work on WordPress.com Free, Personal, or Premium plans.
 
----
+## Install
 
-## Installation
-
-### 1. Install the MCP Adapter plugin
-
-This plugin depends on the MCP Adapter being installed and active. Install it first from the official [WordPress MCP Adapter project](https://github.com/WordPress/mcp-adapter) or its [latest release](https://github.com/WordPress/mcp-adapter/releases/latest), then upload and activate it in **WP Admin → Plugins → Add New → Upload Plugin**.
-
-### 2. Install Webmastery Site Toolkit for MCP
-
-> **Coming soon to the WordPress Plugin Directory** — this plugin has been submitted for review. Once approved you'll be able to install it from **WP Admin → Plugins → Add New** by searching its name. Until then, use one of the options below.
-
-**Option A — Upload zip (recommended)**
+Install the MCP Adapter first, then install this plugin.
 
 ```bash
 git clone https://github.com/DanielBoring/webmastery-site-toolkit-for-mcp.git webmastery-site-toolkit-for-mcp
 zip -r webmastery-site-toolkit-for-mcp.zip webmastery-site-toolkit-for-mcp --exclude='webmastery-site-toolkit-for-mcp/.git/*'
 ```
 
-Then in WP Admin: **Plugins → Add New → Upload Plugin**, upload the zip, **Install Now**, **Activate**.
+Upload `webmastery-site-toolkit-for-mcp.zip` in **WP Admin > Plugins > Add New > Upload Plugin**, then activate it.
 
-**Option B — Direct file copy (server access)**
+## Connect Your MCP Client
 
-```bash
-cp -r webmastery-site-toolkit-for-mcp /var/www/html/wp-content/plugins/
-wp plugin activate webmastery-site-toolkit-for-mcp
-```
-
-### 3. Create a dedicated WordPress user
-
-Create a dedicated user for your agent rather than using your personal admin account — it limits what the agent can do and makes access easy to revoke. In **WP Admin → Users → Add New User**, set a username (e.g. `ai-editor`), an email, and the **Role** to **Editor**.
-
-> **Why Editor and not Administrator?** Editor covers posts, pages, taxonomy, comments, and media. User lookup, user access auditing, plugin management, and site-audit abilities require Administrator capabilities (`list_users`, `edit_users`, `activate_plugins`, `manage_options`) — keep a *separate* Administrator service account for those and use the Editor account for day-to-day content.
-
-### 4. Create an application password
-
-Application passwords are separate from the login password and can be revoked independently. Edit the dedicated user → **Application Passwords** → enter a name (e.g. `Claude Code`) → **Add New Application Password** → copy it immediately (it's shown once). It looks like `xxxx xxxx xxxx xxxx xxxx xxxx` — keep the spaces.
-
-### 5. Connect your MCP client
-
-Configure `@automattic/mcp-wordpress-remote` to point at the MCP Adapter endpoint on your site. Every client uses the same three environment variables; set `WP_API_URL` to the full `/wp-json/mcp/mcp-adapter-default-server` URL.
-
-Most clients use this JSON block (the root key and file location vary — see the table below):
+All local stdio clients use the same three environment variables. Set `WP_API_URL` to the full MCP Adapter endpoint for your site.
 
 ```json
 {
@@ -172,18 +106,7 @@ Most clients use this JSON block (the root key and file location vary — see th
 }
 ```
 
-| Client                     | Config file                                                                 | Root key      | Notes                                                                 |
-| -------------------------- | --------------------------------------------------------------------------- | ------------- | --------------------------------------------------------------------- |
-| **Claude Code**            | `.mcp.json` (project) or `~/.claude.json` (global)                          | `mcpServers`  | Or run `claude mcp add-json`. **Not** `~/.claude/settings.json`.      |
-| **Claude Desktop**         | `~/Library/Application Support/Claude/claude_desktop_config.json` (Mac) · `%APPDATA%\Claude\claude_desktop_config.json` (Win) | `mcpServers`  | —                                                                     |
-| **GitHub Copilot (VS Code)** | `.vscode/mcp.json` (workspace) or VS Code user profile (global)           | `servers`     | Requires VS Code 1.99+. Uses `servers`, **not** `mcpServers`.         |
-| **GitHub Copilot CLI**     | `~/.copilot/mcp-config.json`                                                 | `mcpServers`  | —                                                                     |
-| **Codex**                  | `~/.codex/config.toml` (global) or `.codex/config.toml` (project)           | TOML tables   | TOML, not JSON — see snippet below.                                   |
-| **Windsurf**               | `~/.codeium/windsurf/mcp_config.json`                                        | `mcpServers`  | —                                                                     |
-| **Gemini CLI**             | `~/.gemini/settings.json`                                                    | `mcpServers`  | —                                                                     |
-| **ChatGPT**                | Settings → Connected Apps (web UI)                                           | n/a           | Remote HTTP endpoints only; needs a publicly hosted server + Business/Enterprise/Edu plan. |
-
-**Codex** (`~/.codex/config.toml`) uses TOML instead of JSON:
+Codex uses TOML instead of JSON:
 
 ```toml
 [mcp_servers.wordpress]
@@ -196,60 +119,33 @@ WP_API_USERNAME = "ai-editor"
 WP_API_PASSWORD = "xxxx xxxx xxxx xxxx xxxx xxxx"
 ```
 
-### 6. Verify
+Other clients mostly differ by config file location and root key. See the [full setup guide](https://www.virtuallyboring.com/webmastery-site-toolkit-for-mcp/#connect-your-mcp-client) for Claude Code, Claude Desktop, VS Code Copilot, Copilot CLI, Codex, Windsurf, Gemini CLI, and ChatGPT notes.
 
-See [Verification](#verification) below.
+## Verify
 
----
+Ask your MCP client to call `mcp-adapter-discover-abilities`. It should show the MCP Adapter discovery tools plus this plugin's `webmastery-site-toolkit-for-mcp/*` abilities.
 
-## Verification
+Try a few safe checks:
 
-`mcp-adapter-discover-abilities` is an MCP tool registered by the MCP Adapter plugin — not a CLI command. Invoke it through your assistant's chat by asking it to call the tool (e.g. *"Call mcp-adapter-discover-abilities"*). You should see the adapter's built-in meta/discovery abilities plus all abilities registered by this plugin.
+- `webmastery-site-toolkit-for-mcp/list-posts` - "List the 5 most recent published posts."
+- `webmastery-site-toolkit-for-mcp/get-site-info` - "Get safe public context for this WordPress site."
+- `webmastery-site-toolkit-for-mcp/webmaster-verification-status` - "Check public Google and Bing webmaster verification signals."
+- `webmastery-site-toolkit-for-mcp/plugin-audit` - "Audit installed plugins." Requires an Administrator service account.
 
-To confirm everything works, ask your agent to call a few:
-
-- `webmastery-site-toolkit-for-mcp/list-posts` — *"List the 5 most recent published posts"*
-- `webmastery-site-toolkit-for-mcp/bulk-publish-posts` — *"Publish these draft post IDs: 42, 43, and 44"*
-- `webmastery-site-toolkit-for-mcp/list-revisions` — *"Show saved revisions for post 42"*
-- `webmastery-site-toolkit-for-mcp/update-post-meta` — *"Set the campaign_brief custom field on post 42"*
-- `webmastery-site-toolkit-for-mcp/list-post-types` — *"Show eligible custom post types and their generated abilities"*
-- `webmastery-site-toolkit-for-mcp/list-posts-no-featured-image` — *"Find published posts missing a featured image"*
-- `webmastery-site-toolkit-for-mcp/list-stuck-scheduled` — *"Find scheduled posts that missed their publish time"*
-- `webmastery-site-toolkit-for-mcp/reply-comment` — *"Reply to comment 123 with a helpful follow-up"*
-- `webmastery-site-toolkit-for-mcp/update-comment` — *"Update comment 123 and approve it"*
-- `webmastery-site-toolkit-for-mcp/get-site-info` — *"Get stable public metadata for this WordPress site"*
-- `webmastery-site-toolkit-for-mcp/webmaster-verification-status` — *"Check public Google and Bing webmaster verification signals"*
-- `webmastery-site-toolkit-for-mcp/get-category` — *"Get category 12"*
-- `webmastery-site-toolkit-for-mcp/plugin-audit` (Administrator account) — *"Audit installed plugins for inactive, outdated, or potentially abandoned plugins"*
-- `webmastery-site-toolkit-for-mcp/user-access-audit` (Administrator account) — *"Audit administrator accounts and application passwords"*
-- `webmastery-site-toolkit-for-mcp/security-audit` (Administrator account) — *"Run a security audit of my WordPress site"*
-- `webmastery-site-toolkit-for-mcp/site-health-check` (Administrator account) — *"Check WordPress site health"*
-- `webmastery-site-toolkit-for-mcp/database-health` (Administrator account) — *"Audit database bloat and table sizes"*
-- `webmastery-site-toolkit-for-mcp/performance-status` (Administrator account) — *"Check caching and performance configuration"*
-- `webmastery-site-toolkit-for-mcp/backup-status` (Administrator account) — *"Check whether a known backup plugin is active and when it last ran"*
-
----
+If discovery shows fewer abilities than this repo documents, the connected WordPress site is running an older deployed copy of the plugin. Update the site plugin, then run discovery again.
 
 ## Security
 
-- All abilities enforce WordPress capability checks via `permission_callback` — an editor cannot call abilities that require admin caps.
-- Custom post type abilities use each CPT's registered capability map instead of generic post or page capabilities.
-- Site introspection abilities intentionally exclude filesystem paths, raw server internals, secrets, auth keys, salts, and configuration values beyond the documented fields.
-- `user-access-audit` is read-only and requires `edit_users` because it enumerates administrator accounts and application passwords issued to those accounts. It returns application password names and last-used timestamps, never password secrets.
-- `plugin-audit` is read-only and does not call WordPress.org directly; it uses the cached update transient already maintained by WordPress core. It requires `activate_plugins` because installed plugin names, basenames, versions, and compatibility metadata expose the site's plugin attack surface.
-- Performance status is Administrator-only because it reads configuration constants, plugin activation options, and cache drop-in presence from `wp-content`.
-- `delete-post`, `delete-page`, and `bulk-trash-posts` move content to trash, not permanent deletion; use `restore-post` / `restore-page` to undo individual items.
-- `reply-comment` requires `edit_posts` and object-level edit access to the related post; `update-comment` and moderation status changes require `moderate_comments`.
-- Content hygiene abilities are read-only diagnostics and still honor WordPress ownership scoping; Author-role accounts see only content and media they can edit, while Editors can audit site-wide editorial content.
-- `restore-revision` uses WordPress core revision restore APIs and requires `edit_posts` plus object-level edit access for the parent post or page.
-- `patch-content-block` and `patch-post-content` support optional hash preconditions and fail safely when a target is missing, ambiguous, or stale.
-- Post and page create/update meta writes are limited to REST-registered keys and supported Yoast SEO protected keys; unsupported keys fail with a structured `meta_write_failed` response. Dedicated post meta abilities require `edit_post` for the target post, reject unsafe keys and oversized values, support scalar and JSON object/array values, and deny `_`-prefixed protected keys unless the plugin explicitly allowlists them.
-- Content is sanitized on write. Reads and writes go through the WordPress API except `database-health`, which uses read-only `$wpdb` queries for administrator-only database diagnostics.
+- Use a dedicated service account, not your personal account.
+- Use **Editor** for routine content work and a separate **Administrator** account only for sensitive audits or plugin management.
+- WordPress capability checks gate every ability.
+- Deletes for posts and pages move content to trash; media deletion is permanent.
+- Block and partial-content edits can use hash preconditions and fail when a target is missing, ambiguous, or stale.
+- Site info abilities deliberately avoid secrets, filesystem paths, salts, auth keys, and raw server internals.
+- `plugin-audit`, `user-access-audit`, `database-health`, `performance-status`, `backup-status`, `security-audit`, and `site-health-check` are Administrator-only.
 
-📖 **[Full security model](https://www.virtuallyboring.com/webmastery-site-toolkit-for-mcp/#security)**, including plugin-management safeguards and the complete sanitization rules.
+Read the [full security model](https://www.virtuallyboring.com/webmastery-site-toolkit-for-mcp/#security) before giving an agent Administrator credentials.
 
----
+## Contributing
 
-## Contributing & versioning
-
-New abilities and feature requests are tracked in [GitHub Issues](https://github.com/DanielBoring/webmastery-site-toolkit-for-mcp/issues). The project follows [Semantic Versioning](https://semver.org/) — see [`CONTRIBUTING.md`](CONTRIBUTING.md#versioning-policy) for the full release policy.
+New abilities and feature requests are tracked in [GitHub Issues](https://github.com/DanielBoring/webmastery-site-toolkit-for-mcp/issues). The project follows [Semantic Versioning](https://semver.org/); see [CONTRIBUTING.md](CONTRIBUTING.md#versioning-policy) for release and QA expectations.

--- a/composer.json
+++ b/composer.json
@@ -6,24 +6,48 @@
 	"require": {},
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.1",
+		"php-stubs/wordpress-stubs": "^6.8",
+		"phpstan/phpstan": "^1.12",
+		"phpunit/phpunit": "^9.6",
 		"squizlabs/php_codesniffer": "^3.10",
 		"wp-coding-standards/wpcs": "^3.1"
 	},
 	"scripts": {
+		"audit:locked": "composer audit --locked",
+		"contract": "bash scripts/e2e-test.sh contract",
 		"diff-check": "git diff --check",
-		"e2e": "bash scripts/e2e-test.sh",
-		"phpcs": "phpcs --standard=phpcs.xml.dist",
-		"phpcbf": "phpcbf --standard=phpcs.xml.dist",
+		"e2e": "bash scripts/e2e-test.sh all",
+		"lint:php": "php scripts/php-lint.php",
+		"phpcs": "php vendor/squizlabs/php_codesniffer/bin/phpcs --standard=phpcs.xml.dist",
+		"phpcbf": "php vendor/squizlabs/php_codesniffer/bin/phpcbf --standard=phpcs.xml.dist",
+		"phpstan": "php vendor/phpstan/phpstan/phpstan analyse --configuration=phpstan.neon.dist --memory-limit=2G",
 		"qa": [
+			"@qa:static",
+			"@qa:unit"
+		],
+		"qa:contract": "@contract",
+		"qa:e2e": "bash scripts/e2e-test.sh e2e",
+		"qa:release": "bash scripts/release-qa.sh",
+		"qa:static": [
+			"@lint:php",
 			"@phpcs",
+			"@phpstan",
+			"@audit:locked",
 			"@validate:e2e-manifest",
 			"@diff-check"
+		],
+		"qa:unit": "php vendor/phpunit/phpunit/phpunit --configuration=phpunit.xml.dist",
+		"test": [
+			"@qa:unit"
 		],
 		"validate:e2e-manifest": "php scripts/validate-e2e-manifest.php"
 	},
 	"config": {
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true
+		},
+		"platform": {
+			"php": "8.0.0"
 		},
 		"sort-packages": true
 	}

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0e9440e805a04ea9d6bf509d7b408742",
+    "content-hash": "d507333b607684219bc2669d5ab4b81e",
     "packages": [],
     "packages-dev": [
         {
@@ -102,6 +102,364 @@
                 }
             ],
             "time": "2026-05-06T08:26:05+00:00"
+        },
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^11",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^0.16 || ^1",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.30 || ^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-12-30T00:15:36+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+            },
+            "time": "2025-12-06T11:56:16+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "php-stubs/wordpress-stubs",
+            "version": "v6.9.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/wordpress-stubs.git",
+                "reference": "90a9412826b9944f93b10bf41d795b5fe68abcd5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/90a9412826b9944f93b10bf41d795b5fe68abcd5",
+                "reference": "90a9412826b9944f93b10bf41d795b5fe68abcd5",
+                "shasum": ""
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "5.6.1"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "nikic/php-parser": "^5.5",
+                "php": "^7.4 || ^8.0",
+                "php-stubs/generator": "^0.8.6",
+                "phpdocumentor/reflection-docblock": "^6.0",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^9.5",
+                "symfony/polyfill-php80": "*",
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.1.1",
+                "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
+            },
+            "suggest": {
+                "paragonie/sodium_compat": "Pure PHP implementation of libsodium",
+                "symfony/polyfill-php80": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WordPress function and class declaration stubs for static analysis.",
+            "homepage": "https://github.com/php-stubs/wordpress-stubs",
+            "keywords": [
+                "PHPStan",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.4"
+            },
+            "time": "2026-05-01T20:36:01+00:00"
         },
         {
             "name": "phpcsstandards/phpcsextra",
@@ -279,6 +637,1500 @@
             "time": "2025-12-08T14:27:58+00:00"
         },
         {
+            "name": "phpstan/phpstan",
+            "version": "1.12.33",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/37982d6fc7cbb746dda7773530cda557cdf119e1",
+                "reference": "37982d6fc7cbb746dda7773530cda557cdf119e1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-28T20:30:03+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.32",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-22T04:23:01+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "3.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-02T12:48:52+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:16:10+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "9.6.34",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b36f02317466907a230d3aa1d34467041271ef4a",
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.5.0 || ^2",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=7.3",
+                "phpunit/php-code-coverage": "^9.2.32",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
+                "sebastian/comparator": "^4.0.10",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.8",
+                "sebastian/global-state": "^5.0.8",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
+                "sebastian/version": "^3.0.2"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.34"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-27T05:45:00+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:27:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:30:19+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "4.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:22:56+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:19:30+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:30:58+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "5.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:03:51+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "4.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:03:27+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "5.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T07:10:35+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:20:34+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:12:34+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:14:26+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T06:57:39+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-14T16:00:52+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:13:03+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
             "name": "squizlabs/php_codesniffer",
             "version": "3.13.5",
             "source": {
@@ -358,6 +2210,56 @@
             "time": "2025-11-04T16:30:35+00:00"
         },
         {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
+        },
+        {
             "name": "wp-coding-standards/wpcs",
             "version": "3.3.0",
             "source": {
@@ -431,5 +2333,8 @@
     "prefer-lowest": false,
     "platform": {},
     "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.0.0"
+    },
     "plugin-api-version": "2.9.0"
 }

--- a/docs/qa-strategy.md
+++ b/docs/qa-strategy.md
@@ -1,0 +1,170 @@
+# QA Strategy
+
+This repository uses QA as a set of layered confidence checks. Each layer answers a different question, from "does the PHP parse?" to "can a real MCP client change WordPress content through the adapter?"
+
+The goal is not to run every expensive check for every typo. The goal is to run the cheapest useful checks first, then run Docker and release checks when a change can affect runtime behavior or shipping.
+
+## The five QA layers
+
+| Layer | Command | What it proves | When it should run |
+| --- | --- | --- | --- |
+| Static QA | `composer qa:static` | PHP files parse, WordPress Coding Standards pass, PHPStan can analyze the plugin at the configured level, Composer dependencies have no known locked advisories, the E2E manifest is structurally valid, and the diff has no whitespace errors. | Every PR and every push to `main`. |
+| Unit Tests | `composer qa:unit` | Small pieces of PHP logic behave correctly without booting WordPress. These tests are the fast safety net for sanitization, response shape, and helper behavior. | Every PR and every push to `main`. |
+| Ability Contract QA | `composer qa:contract` or `bash scripts/e2e-test.sh contract` | WordPress boots in Docker, required plugins load, every registered ability is represented in `tests/e2e/abilities-manifest.json`, manifest cases execute through `wp_get_ability()->execute()`, and the debug log stays clean. | Runtime PRs, `main`, releases, and manual dispatch. |
+| Full MCP E2E QA | `composer qa:e2e` or `bash scripts/e2e-test.sh e2e` | A real MCP HTTP JSON-RPC session can discover and execute abilities through the MCP Adapter, including editor CRUD and subscriber denial. | Runtime PRs, `main`, releases, and manual dispatch. |
+| Release Package QA | `composer qa:release` or `bash scripts/release-qa.sh` | The version metadata is aligned, the release zip contains only packaged plugin files, and WordPress Plugin Check evaluates the built package instead of the development checkout. | Release PRs, tags, and manual dispatch. |
+
+## Ability Contract QA vs Full MCP E2E QA
+
+These two checks both use Docker WordPress, but they prove different things.
+
+Ability Contract QA is the plugin contract layer. It asks: "Inside WordPress, did this plugin register the abilities we expect, and do the manifest cases pass with the right permissions and response shapes?" It is broad and ability-driven.
+
+Full MCP E2E QA is the real transport layer. It asks: "Can an MCP client actually talk to WordPress through the MCP Adapter and perform real work?" It is narrower but deeper, because it uses Application Passwords, MCP session initialization, `tools/list`, ability discovery, and real CRUD calls over HTTP JSON-RPC.
+
+Both layers matter. Contract QA catches broad ability drift. Full MCP E2E catches transport and integration problems that direct PHP execution cannot see.
+
+## Possible future advanced QA layer
+
+An advanced MCP manifest replay layer could exercise selected or all `tests/e2e/abilities-manifest.json` cases through the real MCP Adapter HTTP JSON-RPC transport instead of direct `wp_get_ability()->execute()` calls.
+
+This would answer a stronger question than the current Full MCP E2E QA: "Can the same ability cases that pass inside WordPress also pass when invoked by a real MCP client through `mcp-adapter-execute-ability`?"
+
+This should remain separate from the default Full MCP E2E QA unless the project needs deeper transport coverage. Replaying the full manifest over MCP would be slower and more brittle than Ability Contract QA, and it would duplicate much of the same behavioral coverage. A future implementation could use a dedicated command such as `composer qa:mcp-manifest` or `bash scripts/e2e-test.sh mcp-manifest`, with options to run a focused subset for changed abilities and a full replay for release candidates or manual investigations.
+
+## GitHub Actions trigger matrix
+
+| Event or change type | Static QA | Unit Tests | Ability Contract QA | Full MCP E2E QA | Release Package QA |
+| --- | --- | --- | --- | --- | --- |
+| Docs-only PR | Required | Required | Skipped unless manually dispatched | Skipped unless manually dispatched | Skipped |
+| Runtime PR | Required | Required | Required | Required | Skipped unless release-impacting |
+| Push to `main` | Required | Required | Required when runtime files changed | Required when runtime files changed | Skipped |
+| Release PR | Required | Required | Required | Required | Required |
+| Tag `v*` | Optional through previous PR checks | Optional through previous PR checks | Covered by release QA | Covered by release QA | Required |
+| `workflow_dispatch` | Runs selected workflow | Runs selected workflow | Runs | Runs | Runs |
+
+Runtime-impacting paths include plugin source, tests, scripts, Docker configuration, Composer files, workflow files, package metadata, and `readme.txt`.
+
+## Branch protection recommendation
+
+Require these checks before merging any PR:
+
+- `Static QA`
+- `Unit Tests`
+
+Require these checks before merging runtime-impacting PRs:
+
+- `Ability Contract QA`
+- `Full MCP E2E QA`
+
+Require release/package QA before publishing a release:
+
+- `Release Package QA`
+
+The important GitHub concept is "required status checks." A workflow can run on many events, but branch protection decides which successful checks are required before a PR can merge.
+
+## Which command should I run?
+
+For a docs-only change:
+
+```bash
+composer qa
+```
+
+For a normal code bugfix:
+
+```bash
+composer qa
+E2E_MANAGE_COMPOSE=1 composer qa:contract
+E2E_MANAGE_COMPOSE=1 composer qa:e2e
+```
+
+For a new or changed ability:
+
+```bash
+composer qa
+E2E_MANAGE_COMPOSE=1 composer qa:contract
+E2E_MANAGE_COMPOSE=1 composer qa:e2e
+```
+
+For release preparation:
+
+```bash
+composer qa
+E2E_MANAGE_COMPOSE=1 composer qa:contract
+E2E_MANAGE_COMPOSE=1 composer qa:e2e
+composer qa:release
+```
+
+PowerShell users can use the local wrapper:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/qa-local.ps1
+powershell -ExecutionPolicy Bypass -File scripts/qa-local.ps1 -Contract
+powershell -ExecutionPolicy Bypass -File scripts/qa-local.ps1 -E2E
+powershell -ExecutionPolicy Bypass -File scripts/qa-local.ps1 -Release
+```
+
+Bash users can use the local wrapper:
+
+```bash
+scripts/qa-local.sh
+scripts/qa-local.sh --contract
+scripts/qa-local.sh --e2e
+scripts/qa-local.sh --release
+```
+
+## Environment notes
+
+The QA layers are the same in every environment, but the safest entrypoint differs by shell.
+
+### GitHub Actions
+
+GitHub Actions is the authoritative validation gate before merge. The workflows install their own PHP and Composer runtime, use Ubuntu shell tools, and run Docker jobs on GitHub-hosted Linux runners.
+
+Use branch protection to require the relevant workflow checks instead of relying only on a contributor's local machine. At minimum, require Static QA and Unit Tests for every PR. For runtime-impacting PRs, require Ability Contract QA and Full MCP E2E QA.
+
+### Windows PowerShell
+
+PowerShell users should prefer the local wrapper because it checks prerequisites and gives Windows-specific hints:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/qa-local.ps1
+powershell -ExecutionPolicy Bypass -File scripts/qa-local.ps1 -Contract
+powershell -ExecutionPolicy Bypass -File scripts/qa-local.ps1 -E2E
+powershell -ExecutionPolicy Bypass -File scripts/qa-local.ps1 -Release
+```
+
+Docker Desktop must be running for Docker QA. Native `php`, `composer`, and archive tooling may depend on Windows PATH setup. When the native PHP/Composer path is not available, the project can still run many checks through Docker-based PHP/Composer commands.
+
+### Windows Git Bash
+
+Git Bash users should prefer login-shell style commands for Docker QA:
+
+```bash
+bash -lc './scripts/e2e-test.sh contract'
+bash -lc './scripts/e2e-test.sh e2e'
+bash -lc 'bash scripts/release-qa.sh'
+```
+
+The Docker runner sets `MSYS_NO_PATHCONV=1` so Git Bash does not rewrite Linux container paths such as `/var/www/html/wp-load.php` into Windows paths. This matters because Docker commands in the runner execute inside Linux containers, even though the shell is running on Windows.
+
+Depending on local PATH and Docker Desktop setup, `bash scripts/...` and `bash -lc './scripts/...'` can resolve Docker shims differently. If a plain Git Bash invocation fails locally but GitHub Actions passes, retry with the login-shell form above before assuming the repo script is broken.
+
+### Local caveats
+
+Docker Desktop must be running before Docker QA can start. WordPress, MCP Adapter, Yoast SEO, SEOPress, Plugin Check, and release package checks all depend on network access during fresh local runs.
+
+Local Plugin Check output may include known warnings that are acceptable for this project. The release process should treat unexpected errors as blockers, while the documented warnings in `CONTRIBUTING.md` remain known review items.
+
+## How to read failures
+
+Static QA failures usually mean the code has a syntax, style, static-analysis, manifest-shape, dependency-audit, or whitespace problem. Fix these first because they are the cheapest.
+
+Unit test failures usually mean a small helper contract changed. Either fix the behavior or intentionally update the test if the contract changed.
+
+Ability Contract QA failures usually mean the plugin and manifest disagree, a permission case is wrong, an ability response shape changed, or WordPress logged an error.
+
+Full MCP E2E failures usually mean the real MCP Adapter path broke: session setup, tool discovery, ability execution, WordPress side effects, or denied-role behavior.
+
+Release Package QA failures usually mean the package is not ready to ship: version metadata is out of sync, release notes are missing, dev files leaked into the zip, or Plugin Check found a WordPress.org readiness issue.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,9 @@
+parameters:
+	level: 0
+	paths:
+		- webmastery-site-toolkit-for-mcp.php
+		- includes
+	bootstrapFiles:
+		- vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
+	treatPhpDocTypesAsCertain: false
+	reportUnmatchedIgnoredErrors: false

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<phpunit
+	bootstrap="tests/unit/bootstrap.php"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+>
+	<testsuites>
+		<testsuite name="Unit">
+			<directory>tests/unit</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/readme.txt
+++ b/readme.txt
@@ -9,278 +9,110 @@ License: GPL-2.0+
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Donate link: https://paypal.me/VirtuallyBoring
 
-Adds MCP-powered WordPress abilities for content, media, comments, SEO, audits, health, backups, security, users, plugins, and site info.
+Adds MCP-powered WordPress abilities for content, media, SEO, audits, comments, plugins, users, health, and security.
 
 == Description ==
 
-Webmastery Site Toolkit for MCP is a WordPress plugin that adds MCP-powered site management abilities for posts, revisions, post meta, pages, public custom post types, media, content hygiene diagnostics, comments, plugins, Yoast SEO and SEOPress checks/metadata, webmaster verification signals, site health, database health, performance status, backup status, security audits, user lookup, and non-sensitive site introspection. It works with the [MCP Adapter](https://wordpress.org/plugins/mcp-adapter/) plugin, which provides the transport layer while this plugin registers the abilities an AI agent can call.
+Webmastery Site Toolkit for MCP adds WordPress abilities that AI agents and MCP clients can call through the official [MCP Adapter](https://wordpress.org/plugins/mcp-adapter/) plugin.
 
-Webmastery Site Toolkit for MCP registers abilities across site management groups, giving AI agents and MCP clients a full working vocabulary for your WordPress site:
+The MCP Adapter provides the transport layer. This plugin provides the site-management vocabulary: posts, pages, media, comments, taxonomy, custom post types, post meta, content hygiene, SEO checks, public webmaster verification, site info, health, security, users, plugins, database, performance, and backup status.
 
-**Posts**
-Create, read, update, partially patch, bulk publish drafts, bulk trash, and delete posts. Supports all statuses including scheduled (future) posts, category and tag assignment, pagination, human-readable author fields, and safer targeted content updates.
+Core editorial workflows work well with a dedicated Editor service account. Sensitive workflows such as plugin management, user auditing, site health, database health, backup status, performance status, and security audits require a separate Administrator service account.
 
-**Revisions**
-List saved revisions for posts and pages and restore a post or page to a specific revision. Requires `edit_posts` plus object-level edit access to the parent content.
+Highlights:
 
-**Post Meta**
-Read, update, and delete post custom fields after an object-level `edit_post` check. Unprotected keys are allowed when they pass key and value safety limits; `_`-prefixed protected keys are denied unless explicitly allowlisted by the plugin. Updates support scalar values and JSON object/array values.
+* Create, update, list, restore, trash, bulk publish, and bulk trash posts and pages.
+* Inspect Gutenberg blocks and patch one targeted block or content section instead of rewriting an entire post.
+* Manage categories, tags, comments, media metadata, featured images, and public image URL uploads.
+* Discover eligible public custom post types and use generated CRUD abilities for each one.
+* Read, update, and delete safe post meta, including supported Yoast SEO and SEOPress metadata fields.
+* Run content hygiene checks for orphaned media, missing featured images, and stuck scheduled posts.
+* Inspect safe site, user, and environment context without exposing secrets or raw server internals.
+* Audit plugins, administrator accounts, backups, performance settings, database bloat, site health, and security posture.
+* Analyze SEO metadata and public Google/Bing webmaster verification proof.
 
-**Pages**
-Create, read, update, and delete pages. Supports parent hierarchy, human-readable author fields, and all standard page fields.
+All abilities enforce WordPress capability checks. If the connected account cannot perform the equivalent WordPress action, the ability fails instead of bypassing WordPress permissions.
 
-**Custom Post Types**
-Discover eligible public custom post types and use generated list, get, create, update, and delete abilities for each one. Eligibility requires `public = true`, `_builtin = false`, and `show_ui = true`. Ability names use `list-cpt-{post-type}`, `get-cpt-{post-type}`, `create-cpt-{post-type}`, `update-cpt-{post-type}`, and `delete-cpt-{post-type}`, with stable hash suffixes for rare naming collisions. Each ability uses the custom post type's registered capability map, and create/update calls can assign registered taxonomy terms when the account has the taxonomy's `assign_terms` capability.
-
-**Content Blocks**
-Inspect Gutenberg block paths and hashes, then replace a single block in a post or page by exact path or unique hash.
-
-**Taxonomy**
-List, get, create, update, and delete categories and tags. Category creation and updates support parent hierarchy.
-
-**Comments**
-List comments with filters, create threaded replies as the authenticated user, update comment content, and approve, hold, trash, or mark comments as spam through the standard WordPress comment moderation flow.
-
-**Media**
-List, inspect, update, upload public image URLs, and permanently delete media attachments. Supports MIME type and search filters, pagination, alt text updates, title updates, caption updates, URL safety checks, upload-size enforcement, and optional featured-image assignment.
-
-**Content Hygiene**
-Find common cleanup items: orphaned media not attached or referenced, published posts or pages missing featured images, and scheduled posts whose publish time is already in the past. These read-only diagnostics return empty item lists when no problems are found.
-
-**Users**
-List users with role/search/pagination filters, fetch a single user by ID, and audit administrator accounts and application passwords. Useful for account audits and resolving numeric user IDs from responses that do not already include display names.
-
-**Site Info**
-Inspect stable, non-sensitive context for the site, current authenticated user, and runtime environment. Site details include public URLs, language, WordPress version, active theme name/version, deterministic timezone fallback, multisite status, and permalink structure. User details include profile fields, roles, and a fixed key-capability summary. Environment details include PHP version, database server version, WordPress environment type, and locale only.
-
-**Plugins**
-List installed plugins, audit plugin update/maintenance posture, and manage activation state by canonical plugin basename. Plugin audits are read-only and report inactive plugins, cached update availability, tested-up-to compatibility metadata, potential abandonment, local file age, and cached security-update flags without making network calls. Includes protected-plugin safeguards, multisite-aware network activation handling, and structured errors for capability, context, and identifier failures.
-
-**Site Health**
-Run WordPress's built-in health tests and get results grouped by severity: critical, recommended, and good.
-
-**Database Health**
-Audit read-only database bloat indicators including revision count and revision-limit status, orphaned post meta, expired transients, autoloaded option size, and per-table size details. Requires Administrator access through `manage_options`.
-
-**Performance Status**
-Inspect caching and performance-related configuration: external object cache status, object-cache and advanced-cache drop-ins, active known page-cache plugins, WordPress and PHP memory limits, post revision limit, autosave interval, and script concatenation. Requires Administrator access through `manage_options`.
-
-**Backup Status**
-Detect active known backup plugins, including UpdraftPlus, BackWPup, Duplicator, All-in-One WP Migration, BlogVault, WPvivid, Jetpack/VaultPress, and ManageWP Worker. Reports accessible last-backup and schedule details for UpdraftPlus, last-backup details for BackWPup, and a warning when no known backup plugin is active. Requires Administrator access through `manage_options`.
-
-**Security Audit**
-Check for common misconfigurations: debug mode, file editor exposure, SSL, admin username presence, core and plugin version currency, XML-RPC status, and auth key strength. Returns findings in fail/warn/pass buckets with actionable remediation steps.
-
-**SEO Analysis**
-Analyze individual posts for title length, word count, meta description, focus keyword placement, image alt text, internal links, and slug length. Get a site-wide overview including sitemap and robots.txt accessibility, active SEO provider status, Yoast missing-optimization counts, and SEOPress missing-optimization counts. Read Yoast SEO and readability score lists with pagination and optional post type, status, and modified-after filters. Inspect stored Yoast canonical, breadcrumb, Schema.org, Open Graph, Twitter, inclusive-language score, primary category, robots directive metadata, and generated Yoast head output when Yoast exposes it through REST. Inspect stored SEOPress title, description, target keywords, canonical, Open Graph, Twitter/X, primary category, robots, breadcrumb, News sitemap exclusion, and Video sitemap exclusion metadata.
-
-**Webmaster Verification**
-Check public Google and Bing webmaster verification proof without API credentials. The read-only `webmaster-verification-status` ability reports Google Site Kit installed/active status, rendered homepage verification meta tags, `/BingSiteAuth.xml`, visible DNS TXT verification records when PHP can read them, `robots.txt` sitemap declarations, and same-host sitemap reachability using `pass`, `warn`, and `unknown` statuses.
-
-Post and page create/update abilities can write supported Yoast SEO and SEOPress protected meta keys. Yoast inputs cover title, meta description, focus keyphrase, canonical URL, breadcrumb title, Schema.org page/article types, Open Graph metadata, Twitter metadata, primary category, and robots directives. SEOPress inputs cover title, meta description, target keywords, canonical URL, Open Graph metadata, Twitter/X metadata, primary category, robots noindex/nofollow/noimageindex/noarchive/nosnippet directives, and breadcrumb title. Yoast-specific inputs only write `_yoast_wpseo_*` keys, and SEOPress-specific inputs only write `_seopress_*` keys, so the two SEO plugins can be managed side by side. Unsupported protected or unregistered meta keys fail with structured details instead of being silently ignored. Dedicated post meta abilities can read, update, and delete unprotected custom fields, plus explicitly allowlisted protected keys, only after the current user can edit the target post.
-
-Public webmaster proof is different from confirmed Google Search Console or Bing Webmaster Tools account verification. Account-level confirmation is reported as `unknown` because it would require OAuth/API credentials and a separate security model.
-
-When Yoast SEO is installed, all checks run fully including the Yoast sitemap verification and score-list abilities. Without Yoast, meta description and focus keyword checks will warn on every post (since those fields are never populated), the sitemap check will fail, and score-list abilities will return empty results with a note — the structural checks still work correctly.
-
-All abilities enforce WordPress capability checks — an editor cannot call abilities requiring admin caps. Bulk post operations require `delete_posts` for trashing or `edit_posts` for publishing drafts and return per-ID success and failure summaries. Comment replies require `edit_posts` and object-level edit access to the related post; comment content and moderation updates require `moderate_comments`. Custom post type abilities use each CPT's capability map rather than generic post or page capabilities. Site info abilities require `read` and deliberately exclude filesystem paths, secrets, auth keys, salts, and raw server internals. Content is sanitized on write using WordPress core functions.
+For full setup instructions, ability tables, and the deeper security model, visit:
+https://www.virtuallyboring.com/webmastery-site-toolkit-for-mcp/
 
 == Installation ==
 
-1. Install and activate the [MCP Adapter](https://wordpress.org/plugins/mcp-adapter/) plugin first — Webmastery Site Toolkit for MCP depends on it.
-2. Upload the `webmastery-site-toolkit-for-mcp` folder to `/wp-content/plugins/`, or install via **Plugins > Add New > Upload Plugin**.
-3. Activate the plugin through the **Plugins** menu in WordPress.
-4. Create a dedicated WordPress user for your AI agent: go to **Users > Add New User**, set the Role to **Editor**, and save. Using a dedicated account limits access and makes it easy to revoke later. If you need user lookup, plugin management, or sensitive site-audit abilities, create a separate dedicated **Administrator** service account because those require administrative capabilities such as `list_users`, `activate_plugins`, or `manage_options`.
-5. Generate an application password for that user: open the user profile, scroll to **Application Passwords**, enter a name (e.g. `MCP Client`), and click **Add New Application Password**. Copy it immediately — it is only shown once.
-6. Configure your MCP client with the site URL, the dedicated username, and the application password. All abilities are then automatically available.
+1. Install and activate the [MCP Adapter](https://wordpress.org/plugins/mcp-adapter/) plugin first.
+2. Upload the `webmastery-site-toolkit-for-mcp` folder to `/wp-content/plugins/`, or install the plugin zip from **Plugins > Add New > Upload Plugin**.
+3. Activate **Webmastery Site Toolkit for MCP** from the WordPress Plugins screen.
+4. Create a dedicated WordPress user for your MCP client. Use Editor for day-to-day content work.
+5. Create an application password for that user from the WordPress user profile screen.
+6. Configure your MCP client with the site endpoint, username, and application password.
+7. Ask your MCP client to call `mcp-adapter-discover-abilities` and confirm the `webmastery-site-toolkit-for-mcp/*` abilities appear.
 
 == Frequently Asked Questions ==
 
-= Does this work on WordPress.com? =
-
-This plugin requires a WordPress installation where custom plugins can be installed — self-hosted WordPress or a managed host (WP Engine, Kinsta, Flywheel, etc.). It is not compatible with WordPress.com Free, Personal, or Premium plans, which do not allow custom plugin installation. WordPress.com Business and Commerce plans do allow plugins and should work.
-
 = Does this work without the MCP Adapter plugin? =
 
-No. Webmastery Site Toolkit for MCP extends the MCP Adapter plugin. Install and activate it first from the plugin directory.
+No. This plugin extends the MCP Adapter plugin and depends on it for MCP transport and ability registration.
 
-= What MCP clients are supported? =
+= Does this work on WordPress.com? =
 
-Any client that speaks the Model Context Protocol and can connect to `@automattic/mcp-wordpress-remote` or an equivalent MCP bridge should work.
+It requires a WordPress site where custom plugins can be installed. Self-hosted WordPress and managed hosts that allow custom plugins should work. WordPress.com Free, Personal, and Premium plans do not allow custom plugin installation.
 
-= Do I need Yoast SEO or SEOPress installed? =
+= Which WordPress role should my agent use? =
 
-No, but behavior differs depending on which SEO plugins are active:
+Use a dedicated Editor account for normal content workflows: posts, pages, taxonomy, comments, media, revisions, content blocks, and content hygiene.
 
-**With Yoast SEO:** Yoast-backed checks run fully — structural analysis can use Yoast meta description and focus keyphrase fields, site-wide Yoast missing-optimization counts are available, Yoast sitemap verification runs, Yoast SEO/readability score lists are available, and Yoast metadata writes/read-only metadata inspection are enabled.
+Use a separate dedicated Administrator account only when you need Administrator-only workflows such as plugin management, user access audits, site health, database health, performance status, backup status, security audits, or site-wide SEO overview.
 
-**With SEOPress:** SEOPress-backed checks and metadata operations are available — structural analysis can use SEOPress meta description and target keyword fields, site-wide SEOPress missing-optimization counts are available, and SEOPress metadata writes/read-only metadata inspection are enabled.
+= Why use a dedicated account? =
 
-**Without either plugin:** Structural title, word count, image alt text, internal link, and slug checks still work correctly. Provider-specific metadata, sitemap, and score fields return empty or warning-style results with explanatory notes.
+A dedicated account limits the agent to the role you choose, makes activity easier to attribute, and lets you revoke access by deleting the application password or user.
 
-= What WordPress user role should I use? =
+= Do I need Yoast SEO or SEOPress? =
 
-For core content workflows, use the **Editor** role. It covers the editorial capabilities used by posts, pages, taxonomy, comments, media, and content hygiene diagnostics: `edit_posts`, `edit_pages`, `delete_posts`, `delete_pages`, `upload_files`, `manage_categories`, and `moderate_comments`.
-
-Comment reply abilities create child comments under an existing parent comment as the authenticated user after validating the parent and related post. Comment update abilities can change content and optionally set the moderation status to `approve`, `hold`, `spam`, or `trash`.
-
-Site introspection and public webmaster verification workflows (`get-site-info`, `get-user-info`, `get-environment-info`, and `webmaster-verification-status`) require only `read`, so they work with Subscriber and higher roles.
-
-Custom post type workflows depend on each CPT's registered capability map. Use `list-post-types` to discover the generated ability names and required capabilities before assigning an MCP service account.
-
-For user lookup, user access auditing, plugin management/auditing, and sensitive site-audit workflows (`list-users`, `get-user`, `user-access-audit`, `list-plugins`, `plugin-audit`, `activate-plugin`, `deactivate-plugin`, `site-health-check`, `database-health`, `performance-status`, `backup-status`, `security-audit`, and `seo-site-overview`), use a separate dedicated **Administrator** account because those abilities require `list_users`, `edit_users`, `activate_plugins`, or `manage_options`.
-
-Note on role scope: the `edit_posts` and `upload_files` capabilities are available to Authors as well, but WordPress scopes results and write access to the authenticated user's own content unless `edit_others_posts` / `delete_others_posts` are also present (which Editors have). Use an Author-role account only if you intentionally want the agent limited to content it created. For full site-wide editorial control, use Editor.
-
-The `upload-image` media ability sideloads public HTTP/HTTPS image URLs into the media library, rejects local/private URL targets, enforces allowed image MIME types and upload-size limits, writes title/alt/caption metadata, and can set the uploaded image as featured when the account can edit the target post or page.
-
-For those workflows, create a second dedicated Administrator service account and keep the Editor account for content. Using two accounts limits blast radius: the Editor account cannot touch site configuration, and the Administrator account is used only for auditing.
-
-Always create a dedicated user for each role rather than using your personal account — this makes access easy to revoke independently.
-
-= How do I verify the plugin is working? =
-
-After activation, call the MCP Adapter discovery tool, `mcp-adapter-discover-abilities`, from your MCP client. You should see the MCP Adapter's built-in meta/discovery abilities plus all abilities registered by this plugin.
+No. Structural SEO checks still work without either plugin. Yoast-specific metadata and score abilities require Yoast SEO. SEOPress-specific metadata inspection and writes require SEOPress.
 
 = Are write operations safe? =
 
-Delete operations for posts and pages, including bulk post trashing, move content to trash. Media delete permanently removes the attachment and its files. Plugin activation and deactivation require Administrator plugin capabilities, and protected-plugin deactivation is blocked unless explicitly forced. All inputs are sanitized using WordPress core functions. Operations go through the WordPress API except `database-health`, which uses read-only `$wpdb` queries for Administrator-only diagnostics.
+Write operations go through WordPress APIs and capability checks. Posts and pages move to trash rather than being permanently deleted. Media deletion is permanent. Block and partial-content patching can use hashes so stale or ambiguous edits fail safely.
 
-Post and page create/update meta writes are limited to REST-registered keys and supported Yoast SEO protected keys. Unsupported keys return `meta_write_failed` with the rejected keys listed in `data.meta.not_written`. Dedicated post meta abilities enforce object-level `edit_post` checks, reject unsafe key names and oversized values, support scalar and JSON object/array values, and deny protected `_`-prefixed keys unless they are explicitly allowlisted by the plugin.
+= What if discovery shows fewer abilities than the documentation? =
 
-For post and page body edits, `list-content-blocks` returns precise block paths and hashes, then `patch-content-block` can replace one exact Gutenberg block by path or unique hash. `patch-post-content` can still update the content under one exact Gutenberg heading or perform a strict exact-match replacement for classic/raw HTML content. These abilities fail when the target is missing, ambiguous, or stale and support optional hash preconditions to avoid overwriting newer edits.
+The connected WordPress site may be running an older plugin version. Update the plugin on that site, then call `mcp-adapter-discover-abilities` again.
+
+= Where is the full documentation? =
+
+The complete ability reference and client setup guide are maintained at:
+https://www.virtuallyboring.com/webmastery-site-toolkit-for-mcp/
 
 == Changelog ==
 
-= 2.4.0 =
-* Add expanded Yoast SEO free metadata coverage for canonical URLs, breadcrumb titles, Schema.org page/article types, Open Graph and Twitter metadata, primary category, robots directives, inclusive-language score inspection, generated Yoast head inspection, and deeper sitemap index diagnostics.
-* Add first-class SEOPress free metadata coverage for titles, descriptions, target keywords, canonical URLs, Open Graph and Twitter/X metadata, primary category, robots directives, breadcrumb titles, read-only metadata inspection, and SEOPress-specific site overview diagnostics.
-
 = 2.3.0 =
-* Add a media sideload ability to upload public image URLs into the media library with URL safety checks, image MIME and upload-size enforcement, optional title/alt/caption metadata, and optional featured-image assignment.
-* Add a read-only webmaster verification status ability for public Google/Bing proof, homepage verification meta tags, Bing XML verification, visible DNS TXT records, robots.txt sitemap declarations, and sitemap reachability without Google or Bing API credentials.
-* Add an Administrator-only user access audit ability for administrator account inventory, default `admin` username detection, administrator application password reporting, warnings, and application-password collection metadata.
-* Add an Administrator-only plugin audit ability for inactive plugins, cached updates, tested-up-to compatibility, potential abandonment, local file age, and cached security-update flags without network calls.
-* Add an Administrator-only backup status ability for known backup plugin detection, UpdraftPlus last-backup and schedule reporting, BackWPup last-backup reporting, and no-backup warnings.
-* Add an Administrator-only performance status ability for object-cache status, page-cache plugin detection, memory limits, revision limits, autosave interval, and script concatenation diagnostics.
-* Add read-only content hygiene abilities to list orphaned media, published posts or pages missing featured images, and stuck scheduled posts with capability checks and empty results when no problems are found.
-* Add an Administrator-only database health ability for revision bloat, orphaned post meta, expired transients, autoloaded option size, and per-table size diagnostics.
-* Add bulk post trash and bulk draft-publish abilities with per-ID success/failure summaries and `delete_posts` / `edit_posts` capability checks.
-* Add discoverability and CRUD abilities for eligible public custom post types, with deterministic naming, CPT-specific capability checks, and taxonomy term assignment support.
-* Add site introspection abilities for stable, non-sensitive site, current-user, and runtime environment context with `read` capability checks.
-* Add post meta read, update, and delete abilities with object-level permissions, protected-key safeguards, typed responses, scalar/JSON value support, and key/value limits.
-* Add revision abilities to list saved post/page revisions and restore a post or page to a specific revision with `edit_posts` and object-level edit checks.
-* Add category and tag get-by-ID abilities requiring `read`, plus category and tag update abilities requiring `manage_categories`.
-* Add `author_name` and `author_login` to post and page responses so listings expose human-readable author details alongside the numeric author ID.
-* Add comment reply and update abilities with threaded reply creation, comment content updates, optional moderation status changes, capability checks, and normalized comment responses.
+* Add public image URL uploads with URL safety checks, image MIME and upload-size enforcement, optional metadata, and optional featured-image assignment.
+* Add public Google/Bing webmaster verification checks without Google or Bing API credentials.
+* Add Administrator-only user access, plugin, database, performance, and backup audits.
+* Add content hygiene diagnostics for orphaned media, posts/pages missing featured images, and stuck scheduled posts.
+* Add bulk post trash and bulk draft-publish abilities with per-ID summaries.
+* Add eligible custom post type discovery and generated CRUD abilities.
+* Add safe site, current-user, and environment introspection abilities.
+* Add post meta read, update, and delete abilities with object-level permissions and protected-key safeguards.
+* Add revision listing and restore abilities for posts and pages.
+* Add category and tag get/update abilities.
+* Add comment reply and update abilities.
+* Add human-readable author fields to post and page responses.
 
 = 2.2.0 =
-* Add Yoast SEO score and readability score abilities with pagination, filters, deterministic newest-modified-first ordering, and explicit empty results when Yoast SEO is not active.
-* Persist supported Yoast SEO protected meta keys from post and page create/update abilities, including focus keyphrase, meta description, and SEO title, and return structured `meta_write_failed` details for meta keys that are not writable.
+* Add Yoast SEO score and readability score abilities.
+* Persist supported Yoast SEO protected meta keys from post and page create/update abilities.
 
 = 2.1.0 =
-* Add `list-content-blocks` and `patch-content-block` for precise Gutenberg block inspection and single-block replacement in posts and pages.
-* Add `patch-post-content` for safer partial post body edits with block-aware heading targeting, exact-match fallback, ambiguous-target failures, and optional content-hash preconditions.
-
-= 2.0.0 =
-* Rename the plugin to Webmastery Site Toolkit for MCP for WordPress.org naming guideline compliance
-* Rename the plugin slug, text domain, package folder, and MCP ability namespace to `webmastery-site-toolkit-for-mcp`
-* Rename PHP class prefixes to `Webmastery_MCP_` for clearer plugin-specific namespacing
-
-= 1.6.1 =
-* Fix release packaging guidance so Plugin Check evaluates the canonical `webmastery-site-toolkit-for-mcp` slug
-* Shorten the WordPress.org short description to stay within parser limits
-* Document accepted Plugin Check warnings for read-only plugin auto-update status reporting and bounded Yoast SEO meta checks
-
-= 1.6.0 =
-* Rename registered MCP ability names and categories to the `webmastery-site-toolkit-for-mcp` plugin slug namespace
-* Add featured image abilities for setting and removing featured images on posts and pages
-* Add restore abilities for restoring trashed posts and pages with object-specific `delete_post` permission checks
-* Preserve backslashes in `create-post` and `update-post` content
-* Add plugin management abilities: `list-plugins`, `activate-plugin`, and `deactivate-plugin`
-* Add guarded plugin activation/deactivation controls with canonical `plugin_basename` identifiers, protected-plugin safeguards, multisite-aware `network_wide` handling, and structured errors
-* Rename plugin/package references to align with Webmastery Site Toolkit for MCP and harden object-specific permission callbacks
-
-= 1.5.1 =
-* Rename plugin to "Webmastery Site Toolkit for MCP" and update slug references to `webmastery-site-toolkit-for-mcp`
-* Replace generic `WP_MCP_` PHP class prefixes with `Webmastery_MCP_`
-* Harden ability permissions with object-specific post/media checks and administrator-only sensitive audit abilities
-* Add WordPress Coding Standards tooling and update WordPress.org plugin-guideline documentation
-
-= 1.5.0 =
-* Add user lookup abilities: `list-users` and `get-user`
-* 30 abilities: posts (5), pages (5), taxonomy (6), comments (4), media (4), users (2), site health (1), security audit (1), SEO analysis (2)
-
-= 1.4.0 =
-* Add media management abilities: `list-media`, `get-media`, `update-media`, and `delete-media`
-* 28 abilities: posts (5), pages (5), taxonomy (6), comments (4), media (4), site health (1), security audit (1), SEO analysis (2)
-
-= 1.3.4 =
-* Rename plugin to "Webmastery Site Toolkit for MCP" to comply with WordPress.org naming guidelines
-
-= 1.3.3 =
-* Update "Tested up to" to WordPress 7.0
-* Suppress false positive PHPCS warning on core xmlrpc_enabled filter check
-* Suppress false positive slow query warnings on Yoast meta_query checks
-
-= 1.3.2 =
-* Bump minimum PHP requirement to 8.0 (str_starts_with is unavailable on PHP 7.4)
-* Add parent field support to create-page and update-page abilities
-* Replace PHP date() with wp_date() per WordPress coding standards
-
-= 1.3.1 =
-* Add `yoast_meta_description` and `yoast_focus_keyword` fields to `update-post` and `update-page`
-
-= 1.3.0 =
-* Initial public release
-* 24 abilities: posts (5), pages (5), taxonomy (6), comments (4), site health (1), security audit (1), SEO analysis (2)
-* Scheduled (future) post status support
-* Yoast SEO integration for SEO analysis abilities
-* Security audit with fail/warn/pass buckets and remediation guidance
+* Add block inspection, single-block replacement, and safer partial post body edits.
 
 == Upgrade Notice ==
 
-= 2.4.0 =
-Expands Yoast SEO metadata coverage and adds first-class SEOPress metadata support so both SEO plugins can be managed side by side.
-
 = 2.3.0 =
-Adds media URL sideloading, webmaster verification checks, content hygiene diagnostics, custom post type CRUD, post meta and revision tools, comment replies and updates, human-readable author fields, and Administrator-only plugin, user access, database, performance, and backup audits.
+Adds media URL uploads, webmaster verification checks, content hygiene diagnostics, CPT CRUD, post meta, revisions, comment replies/updates, and Administrator-only site audits.
 
 = 2.2.0 =
-Adds Yoast score list abilities and fixes supported Yoast protected meta writes for post and page create/update workflows.
+Adds Yoast score list abilities and supported Yoast protected meta writes.
 
 = 2.1.0 =
-Adds safer block-level post and page editing abilities for MCP clients.
-
-= 2.0.0 =
-Renames MCP ability IDs to the `webmastery-site-toolkit-for-mcp` namespace as part of the WordPress.org review rename.
-
-= 1.6.1 =
-Fixes Plugin Check release-readiness items for the WordPress.org package.
-
-= 1.6.0 =
-Renames MCP ability IDs to the `webmastery-site-toolkit-for-mcp` namespace, adds featured image, restore, and plugin management abilities, and fixes post content backslash preservation.
-
-= 1.5.1 =
-Renames the plugin, tightens permission checks, and adds WordPress.org review-readiness tooling.
-
-= 1.5.0 =
-Adds user lookup abilities for resolving WordPress author IDs.
-
-= 1.4.0 =
-Adds media list, get, update, and permanent delete abilities.
-
-= 1.3.4 =
-Plugin renamed to "Webmastery Site Toolkit for MCP".
-
-= 1.3.3 =
-Updates tested up to WordPress 7.0.
-
-= 1.3.2 =
-Requires PHP 8.0+. Adds parent page hierarchy support to create-page and update-page.
-
-= 1.3.1 =
-Adds Yoast meta description and focus keyword fields to update-post and update-page.
-
-= 1.3.0 =
-Initial release.
+Adds safer block-level and partial-content editing abilities for MCP clients.

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+VERSION="${1:-}"
+PLUGIN_SLUG="webmastery-site-toolkit-for-mcp"
+
+if [ -z "$VERSION" ]; then
+	VERSION="$(grep -E '^[[:space:]]*\*?[[:space:]]*Version:[[:space:]]*[0-9]+\.[0-9]+\.[0-9]+' "${PLUGIN_SLUG}.php" | head -1 | sed -E 's/.*Version:[[:space:]]*([0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
+fi
+
+if [ -z "$VERSION" ]; then
+	echo "Could not determine plugin version." >&2
+	exit 1
+fi
+
+PACKAGE_DIR="build/${PLUGIN_SLUG}"
+ZIP_FILE="${PLUGIN_SLUG}-${VERSION}.zip"
+
+rm -rf "$PACKAGE_DIR" "$ZIP_FILE"
+mkdir -p "$PACKAGE_DIR"
+cp "${PLUGIN_SLUG}.php" readme.txt LICENSE "$PACKAGE_DIR/"
+cp -R includes "$PACKAGE_DIR/"
+
+if command -v zip >/dev/null 2>&1; then
+	(
+		cd build
+		zip -qr "../${ZIP_FILE}" "$PLUGIN_SLUG"
+	)
+elif command -v tar >/dev/null 2>&1; then
+	if command -v php >/dev/null 2>&1; then
+		php scripts/create-release-zip.php "$PACKAGE_DIR" "$ZIP_FILE"
+	elif command -v docker >/dev/null 2>&1; then
+		if command -v cygpath >/dev/null 2>&1; then
+			MOUNT_PATH="$(cygpath -w "$(pwd)")"
+		else
+			MOUNT_PATH="$(pwd)"
+		fi
+		docker run --rm -v "${MOUNT_PATH}:/app" -w /app composer:2 php scripts/create-release-zip.php "$PACKAGE_DIR" "$ZIP_FILE"
+	else
+		echo "Missing zip and PHP ZipArchive fallback." >&2
+		exit 1
+	fi
+elif command -v powershell.exe >/dev/null 2>&1; then
+	powershell.exe -NoProfile -Command "Compress-Archive -Path 'build/${PLUGIN_SLUG}' -DestinationPath '${ZIP_FILE}' -Force"
+else
+	echo "Missing zip-compatible archiver. Install zip or tar." >&2
+	exit 1
+fi
+
+echo "$ZIP_FILE"

--- a/scripts/create-release-zip.php
+++ b/scripts/create-release-zip.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+$source_dir = $argv[1] ?? '';
+$zip_file   = $argv[2] ?? '';
+
+if ( '' === $source_dir || '' === $zip_file ) {
+	fwrite( STDERR, "Usage: php scripts/create-release-zip.php <source-dir> <zip-file>\n" );
+	exit( 1 );
+}
+
+if ( ! is_dir( $source_dir ) ) {
+	fwrite( STDERR, "Source directory does not exist: {$source_dir}\n" );
+	exit( 1 );
+}
+
+$zip = new ZipArchive();
+if ( true !== $zip->open( $zip_file, ZipArchive::CREATE | ZipArchive::OVERWRITE ) ) {
+	fwrite( STDERR, "Could not create zip file: {$zip_file}\n" );
+	exit( 1 );
+}
+
+$source_dir = rtrim( str_replace( '\\', '/', realpath( $source_dir ) ?: $source_dir ), '/' );
+$base_dir   = dirname( $source_dir );
+
+$iterator = new RecursiveIteratorIterator(
+	new RecursiveDirectoryIterator( $source_dir, FilesystemIterator::SKIP_DOTS ),
+	RecursiveIteratorIterator::SELF_FIRST
+);
+
+$zip->addEmptyDir( basename( $source_dir ) );
+
+foreach ( $iterator as $file ) {
+	$path          = str_replace( '\\', '/', $file->getPathname() );
+	$relative_path = ltrim( substr( $path, strlen( str_replace( '\\', '/', $base_dir ) ) ), '/' );
+
+	if ( $file->isDir() ) {
+		$zip->addEmptyDir( $relative_path );
+	} else {
+		$zip->addFile( $file->getPathname(), $relative_path );
+	}
+}
+
+$zip->close();

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
+export MSYS_NO_PATHCONV="${MSYS_NO_PATHCONV:-1}"
+
 WORDPRESS_URL="${WORDPRESS_URL:-http://localhost}"
 PLUGIN_SLUG="webmastery-site-toolkit-for-mcp"
 MCP_ADAPTER_ZIP="https://github.com/WordPress/mcp-adapter/releases/download/v0.5.0/mcp-adapter.zip"
@@ -9,6 +11,7 @@ SEOPRESS_PLUGIN_SLUG="${SEOPRESS_PLUGIN_SLUG:-wp-seopress}"
 E2E_ARTIFACTS_DIR="${E2E_ARTIFACTS_DIR:-e2e-artifacts}"
 E2E_MANAGE_COMPOSE="${E2E_MANAGE_COMPOSE:-0}"
 E2E_KEEP_COMPOSE="${E2E_KEEP_COMPOSE:-0}"
+QA_MODE="${1:-all}"
 
 compose() {
 	local project_args=()
@@ -16,11 +19,7 @@ compose() {
 		project_args=( --project-name "$COMPOSE_PROJECT_NAME" )
 	fi
 
-	if docker compose version >/dev/null 2>&1; then
-		docker compose "${project_args[@]}" "$@"
-	else
-		docker-compose "${project_args[@]}" "$@"
-	fi
+	docker compose "${project_args[@]}" "$@"
 }
 
 wp() {
@@ -144,6 +143,25 @@ create_application_password() {
 	wp user application-password create "$user" "$name" --porcelain | tail -n 1 | tr -d '[:space:]'
 }
 
+ensure_user() {
+	local user="$1"
+	local email="$2"
+	local role="$3"
+
+	if wp user get "$user" >/dev/null 2>&1; then
+		wp user set-role "$user" "$role" >/dev/null
+		return 0
+	fi
+
+	wp user create "$user" "$email" --role="$role" --user_pass=password123 >/dev/null
+}
+
+ensure_mcp_crud_users() {
+	echo "Ensuring MCP CRUD E2E users..."
+	ensure_user editor_test editor@test.local editor
+	ensure_user subscriber_test subscriber@test.local subscriber
+}
+
 run_mcp_crud() {
 	echo "Running protocol-level MCP CRUD E2E tests..."
 
@@ -151,6 +169,7 @@ run_mcp_crud() {
 	local subscriber_password
 	local endpoint
 
+	ensure_mcp_crud_users
 	editor_password="$(create_application_password editor_test "MCP CRUD E2E Editor")"
 	subscriber_password="$(create_application_password subscriber_test "MCP CRUD E2E Subscriber")"
 	endpoint="${MCP_CRUD_ENDPOINT:-http://localhost/wp-json/mcp/mcp-adapter-default-server}"
@@ -184,8 +203,18 @@ run_debug_log_check() {
 }
 
 echo "================================"
-echo "E2E Test Suite: WordPress MCP Abilities"
+echo "Docker QA Suite: WordPress MCP Abilities"
 echo "================================"
+
+case "$QA_MODE" in
+	contract|e2e|all)
+		;;
+	*)
+		echo "Unknown QA mode: ${QA_MODE}" >&2
+		echo "Usage: scripts/e2e-test.sh [contract|e2e|all]" >&2
+		exit 1
+		;;
+esac
 
 trap cleanup_compose EXIT
 
@@ -199,9 +228,18 @@ configure_http_auth_forwarding
 configure_application_passwords
 install_plugins
 compose exec -T wordpress rm -f /var/www/html/wp-content/debug.log
-run_php_lint
-run_ability_manifest
-run_mcp_crud
+
+if [ "$QA_MODE" = "contract" ] || [ "$QA_MODE" = "all" ]; then
+	echo "Running Ability Contract QA..."
+	run_php_lint
+	run_ability_manifest
+fi
+
+if [ "$QA_MODE" = "e2e" ] || [ "$QA_MODE" = "all" ]; then
+	echo "Running Full MCP E2E QA..."
+	run_mcp_crud
+fi
+
 run_debug_log_check
 
-echo "E2E QA completed successfully"
+echo "Docker QA (${QA_MODE}) completed successfully"

--- a/scripts/php-lint.php
+++ b/scripts/php-lint.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+$repo_root = dirname(__DIR__);
+$paths     = array(
+	$repo_root . '/webmastery-site-toolkit-for-mcp.php',
+	$repo_root . '/includes',
+	$repo_root . '/scripts',
+	$repo_root . '/tests',
+);
+
+$files = array();
+foreach ( $paths as $path ) {
+	if ( is_file( $path ) && 'php' === pathinfo( $path, PATHINFO_EXTENSION ) ) {
+		$files[] = $path;
+		continue;
+	}
+
+	if ( ! is_dir( $path ) ) {
+		continue;
+	}
+
+	$iterator = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator( $path, FilesystemIterator::SKIP_DOTS )
+	);
+
+	foreach ( $iterator as $file ) {
+		if ( $file->isFile() && 'php' === $file->getExtension() ) {
+			$files[] = $file->getPathname();
+		}
+	}
+}
+
+sort( $files );
+
+$failed = false;
+foreach ( $files as $file ) {
+	$command = escapeshellarg( PHP_BINARY ) . ' -l ' . escapeshellarg( $file );
+	passthru( $command, $exit_code );
+	if ( 0 !== $exit_code ) {
+		$failed = true;
+	}
+}
+
+if ( $failed ) {
+	exit( 1 );
+}
+
+printf( "PASS PHP lint: %d files\n", count( $files ) );

--- a/scripts/qa-local.ps1
+++ b/scripts/qa-local.ps1
@@ -1,5 +1,7 @@
 param(
+	[switch] $Contract,
 	[switch] $E2E,
+	[switch] $Release,
 	[switch] $KeepCompose,
 	[switch] $PreflightOnly
 )
@@ -40,7 +42,7 @@ Test-QACommand 'php'
 Test-QACommand 'composer'
 Test-QACommand 'git'
 
-if ($E2E) {
+if ($Contract -or $E2E -or $Release) {
 	Test-QACommand 'docker'
 	Test-QACommand 'bash'
 }
@@ -50,13 +52,23 @@ if ($PreflightOnly) {
 	exit 0
 }
 
-Invoke-QACommand 'Install Composer dependencies' 'composer' @('install', '--no-interaction')
+Invoke-QACommand 'Install Composer dependencies' 'composer' @('install', '--no-interaction', '--prefer-dist', '--no-progress')
 Invoke-QACommand 'Run Composer QA checks' 'composer' @('qa')
+
+if ($Contract) {
+	$keepComposeValue = if ($KeepCompose) { '1' } else { '0' }
+
+	Invoke-QACommand 'Run Docker Ability Contract QA' 'bash' @('-lc', "E2E_MANAGE_COMPOSE=1 E2E_KEEP_COMPOSE=$keepComposeValue bash scripts/e2e-test.sh contract")
+}
 
 if ($E2E) {
 	$keepComposeValue = if ($KeepCompose) { '1' } else { '0' }
 
-	Invoke-QACommand 'Run Docker E2E QA' 'bash' @('-lc', "E2E_MANAGE_COMPOSE=1 E2E_KEEP_COMPOSE=$keepComposeValue bash scripts/e2e-test.sh")
+	Invoke-QACommand 'Run Docker E2E QA' 'bash' @('-lc', "E2E_MANAGE_COMPOSE=1 E2E_KEEP_COMPOSE=$keepComposeValue bash scripts/e2e-test.sh e2e")
+}
+
+if ($Release) {
+	Invoke-QACommand 'Run Release Package QA' 'bash' @('-lc', 'bash scripts/release-qa.sh')
 }
 
 Write-Host 'Local QA completed successfully.'

--- a/scripts/qa-local.sh
+++ b/scripts/qa-local.sh
@@ -2,27 +2,40 @@
 set -Eeuo pipefail
 
 RUN_E2E=0
+RUN_CONTRACT=0
+RUN_RELEASE=0
 KEEP_COMPOSE=0
 PREFLIGHT_ONLY=0
 
 usage() {
 	cat <<'USAGE'
-Usage: scripts/qa-local.sh [--e2e] [--keep-compose] [--preflight-only]
+Usage: scripts/qa-local.sh [--contract] [--e2e] [--release] [--keep-compose] [--preflight-only]
 
 Runs local preflight QA:
-  - composer install --no-interaction
-  - composer qa
-  - optional Docker E2E via scripts/e2e-test.sh
+  - composer install --no-interaction --prefer-dist --no-progress
+  - composer qa (static + unit)
+  - optional Docker Ability Contract QA
+  - optional Docker Full MCP E2E QA
+  - optional Release Package QA
 
 Options:
+  --contract        run managed Docker Ability Contract QA
+  --e2e             run managed Docker Full MCP E2E QA
+  --release         run Release Package QA
   --preflight-only  check required commands and exit without running QA
 USAGE
 }
 
 while [ "$#" -gt 0 ]; do
 	case "$1" in
+		--contract)
+			RUN_CONTRACT=1
+			;;
 		--e2e)
 			RUN_E2E=1
+			;;
+		--release)
+			RUN_RELEASE=1
 			;;
 		--keep-compose)
 			KEEP_COMPOSE=1
@@ -85,7 +98,7 @@ require_command php
 require_command composer
 require_command git
 
-if [ "$RUN_E2E" = "1" ]; then
+if [ "$RUN_CONTRACT" = "1" ] || [ "$RUN_E2E" = "1" ] || [ "$RUN_RELEASE" = "1" ]; then
 	require_command docker
 	require_command bash
 fi
@@ -95,12 +108,19 @@ if [ "$PREFLIGHT_ONLY" = "1" ]; then
 	exit 0
 fi
 
-run_step composer install --no-interaction
+run_step composer install --no-interaction --prefer-dist --no-progress
 run_step composer qa
 
-if [ "$RUN_E2E" = "1" ]; then
+if [ "$RUN_CONTRACT" = "1" ]; then
+	E2E_MANAGE_COMPOSE=1 E2E_KEEP_COMPOSE="$KEEP_COMPOSE" run_step bash scripts/e2e-test.sh contract
+fi
 
-	E2E_MANAGE_COMPOSE=1 E2E_KEEP_COMPOSE="$KEEP_COMPOSE" run_step bash scripts/e2e-test.sh
+if [ "$RUN_E2E" = "1" ]; then
+	E2E_MANAGE_COMPOSE=1 E2E_KEEP_COMPOSE="$KEEP_COMPOSE" run_step bash scripts/e2e-test.sh e2e
+fi
+
+if [ "$RUN_RELEASE" = "1" ]; then
+	run_step bash scripts/release-qa.sh
 fi
 
 echo "Local QA completed successfully."

--- a/scripts/release-qa.sh
+++ b/scripts/release-qa.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+VERSION="${1:-}"
+PLUGIN_SLUG="webmastery-site-toolkit-for-mcp"
+
+php_run() {
+	if command -v php >/dev/null 2>&1; then
+		php "$@"
+		return $?
+	fi
+
+	if ! command -v docker >/dev/null 2>&1; then
+		echo "PHP is required. Install PHP or Docker to run PHP through the Composer image." >&2
+		exit 1
+	fi
+
+	local mount_path
+	if command -v cygpath >/dev/null 2>&1; then
+		mount_path="$(cygpath -w "$(pwd)")"
+	else
+		mount_path="$(pwd)"
+	fi
+
+	docker run --rm -v "${mount_path}:/app" -w /app composer:2 php "$@"
+}
+
+ZIP_FILE="$(bash scripts/build-release.sh "$VERSION")"
+php_run scripts/validate-release-package.php "$ZIP_FILE" "$VERSION"
+
+if [ "${SKIP_PLUGIN_CHECK:-0}" = "1" ]; then
+	echo "Skipping WordPress Plugin Check because SKIP_PLUGIN_CHECK=1."
+	exit 0
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+	echo "Docker is required for WordPress Plugin Check. Set SKIP_PLUGIN_CHECK=1 to run package validation only." >&2
+	exit 1
+fi
+
+export E2E_MANAGE_COMPOSE=1
+export E2E_KEEP_COMPOSE=1
+trap 'docker compose down -v --remove-orphans >/dev/null 2>&1 || true' EXIT
+
+bash scripts/e2e-test.sh contract
+docker compose exec -T wordpress wp --allow-root plugin install plugin-check --activate --force
+docker compose exec -T wordpress rm -rf "/var/www/html/wp-content/plugins/${PLUGIN_SLUG}-package"
+docker compose cp "build/${PLUGIN_SLUG}" "wordpress:/var/www/html/wp-content/plugins/${PLUGIN_SLUG}-package"
+docker compose exec -T wordpress wp --allow-root plugin check "${PLUGIN_SLUG}-package" --slug="$PLUGIN_SLUG"

--- a/scripts/validate-release-package.php
+++ b/scripts/validate-release-package.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+$repo_root   = dirname(__DIR__);
+$plugin_slug = 'webmastery-site-toolkit-for-mcp';
+$plugin_file = $repo_root . '/' . $plugin_slug . '.php';
+$readme_file = $repo_root . '/readme.txt';
+$zip_file    = $argv[1] ?? '';
+$tag_version = $argv[2] ?? '';
+
+function fail( string $message ): void {
+	fwrite( STDERR, "ERROR {$message}\n" );
+	exit( 1 );
+}
+
+function read_file_or_fail( string $path ): string {
+	$contents = file_get_contents( $path );
+	if ( false === $contents ) {
+		fail( "Could not read {$path}" );
+	}
+
+	return $contents;
+}
+
+$plugin = read_file_or_fail( $plugin_file );
+$readme = read_file_or_fail( $readme_file );
+
+if ( ! preg_match( '/^[ \t]*\*?[ \t]*Version:[ \t]*([0-9]+\.[0-9]+\.[0-9]+)/mi', $plugin, $version_match ) ) {
+	fail( 'Could not parse plugin header Version.' );
+}
+
+if ( ! preg_match( '/^[ \t]*\*?[ \t]*Text Domain:[ \t]*(.+)$/mi', $plugin, $text_domain_match ) ) {
+	fail( 'Could not parse plugin header Text Domain.' );
+}
+
+if ( ! preg_match( '/^Stable tag:[ \t]*(.+)$/mi', $readme, $stable_tag_match ) ) {
+	fail( 'Could not parse readme.txt Stable tag.' );
+}
+
+$plugin_version = trim( $version_match[1] );
+$text_domain    = trim( $text_domain_match[1] );
+$stable_tag     = trim( $stable_tag_match[1] );
+$expected       = '' !== $tag_version ? ltrim( $tag_version, 'v' ) : $plugin_version;
+
+if ( $plugin_slug !== $text_domain ) {
+	fail( "Text Domain ({$text_domain}) does not match {$plugin_slug}." );
+}
+if ( $expected !== $plugin_version ) {
+	fail( "Expected version ({$expected}) does not match plugin header ({$plugin_version})." );
+}
+if ( $expected !== $stable_tag ) {
+	fail( "Expected version ({$expected}) does not match readme stable tag ({$stable_tag})." );
+}
+
+$readme_lines       = preg_split( '/\R/', $readme );
+$after_donate_link  = false;
+$short_description  = '';
+foreach ( $readme_lines as $line ) {
+	if ( preg_match( '/^Donate link:/i', $line ) ) {
+		$after_donate_link = true;
+		continue;
+	}
+	if ( $after_donate_link && '' !== trim( $line ) ) {
+		$short_description = trim( $line );
+		break;
+	}
+}
+
+if ( strlen( $short_description ) > 150 ) {
+	fail( 'readme.txt short description exceeds 150 characters.' );
+}
+
+if ( ! preg_match( '/^= ' . preg_quote( $expected, '/' ) . ' =\s*$/mi', $readme ) ) {
+	fail( "No plugin release notes found in readme.txt for {$expected}." );
+}
+
+if ( '' !== $zip_file ) {
+	if ( ! is_file( $zip_file ) || 0 === filesize( $zip_file ) ) {
+		fail( "Missing or empty release artifact: {$zip_file}" );
+	}
+
+	$zip = new ZipArchive();
+	if ( true !== $zip->open( $zip_file ) ) {
+		fail( "Could not open release artifact: {$zip_file}" );
+	}
+
+	$entries = array();
+	for ( $i = 0; $i < $zip->numFiles; $i++ ) {
+		$entries[] = $zip->getNameIndex( $i );
+	}
+	$zip->close();
+
+	foreach ( array( "{$plugin_slug}/{$plugin_slug}.php", "{$plugin_slug}/readme.txt", "{$plugin_slug}/LICENSE" ) as $required ) {
+		if ( ! in_array( $required, $entries, true ) ) {
+			fail( "Release artifact is missing {$required}." );
+		}
+	}
+
+	$forbidden_pattern = '#^' . preg_quote( $plugin_slug, '#' ) . '/(\.git|\.github|assets|build|e2e-artifacts|scripts|tests|vendor)/|^' . preg_quote( $plugin_slug, '#' ) . '/(BACKLOG|CHANGELOG|CONTRIBUTING|README)\.md$|^' . preg_quote( $plugin_slug, '#' ) . '/(composer\.(json|lock)|docker-compose\.yml|phpcs\.xml\.dist|\.gitattributes|\.gitignore)$#';
+	foreach ( $entries as $entry ) {
+		if ( preg_match( $forbidden_pattern, $entry ) ) {
+			fail( "Release artifact contains repository-only file: {$entry}" );
+		}
+	}
+}
+
+echo "PASS release package validation for {$expected}\n";

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,9 +1,11 @@
-# E2E Ability Coverage Contract
+# Ability Contract and Full MCP E2E QA
 
-The E2E suite has two layers:
+For the full repository QA posture, including static checks, unit tests, release checks, and GitHub Actions trigger policy, see [`docs/qa-strategy.md`](../../docs/qa-strategy.md).
 
-1. The light manifest suite is ability-driven. Every registered `webmastery-site-toolkit-for-mcp/*` ability must be represented in `tests/e2e/abilities-manifest.json`.
-2. The secondary in-depth CRUD QA suite uses real MCP Adapter HTTP JSON-RPC requests against `/wp-json/mcp/mcp-adapter-default-server` to prove a remote MCP client can create, read, update, and delete content through the adapter transport.
+The Docker QA suite has two layers:
+
+1. Ability Contract QA is ability-driven. Every registered `webmastery-site-toolkit-for-mcp/*` ability must be represented in `tests/e2e/abilities-manifest.json`.
+2. Full MCP E2E QA uses real MCP Adapter HTTP JSON-RPC requests against `/wp-json/mcp/mcp-adapter-default-server` to prove a remote MCP client can create, read, update, and delete content through the adapter transport.
 
 Current coverage is 71 base registered abilities plus 5 generated abilities per eligible custom post type. The E2E runner registers two fixture custom post types, so the manifest covers 81 abilities across 174 test cases, including custom post type discovery and CRUD permission coverage for two capability maps, taxonomy get/update permission coverage, post and page listing response-shape assertions, expanded Yoast and SEOPress metadata write coverage, the bulk post abilities `webmastery-site-toolkit-for-mcp/bulk-trash-posts` and `webmastery-site-toolkit-for-mcp/bulk-publish-posts`, the revision abilities `webmastery-site-toolkit-for-mcp/list-revisions` and `webmastery-site-toolkit-for-mcp/restore-revision`, the post meta abilities `webmastery-site-toolkit-for-mcp/get-post-meta`, `webmastery-site-toolkit-for-mcp/update-post-meta`, and `webmastery-site-toolkit-for-mcp/delete-post-meta`, the block editing abilities `webmastery-site-toolkit-for-mcp/list-content-blocks`, `webmastery-site-toolkit-for-mcp/patch-content-block`, and `webmastery-site-toolkit-for-mcp/patch-post-content`, the comment interaction abilities `webmastery-site-toolkit-for-mcp/reply-comment` and `webmastery-site-toolkit-for-mcp/update-comment`, the media sideload ability `webmastery-site-toolkit-for-mcp/upload-image`, the content hygiene abilities `webmastery-site-toolkit-for-mcp/list-orphaned-media`, `webmastery-site-toolkit-for-mcp/list-posts-no-featured-image`, and `webmastery-site-toolkit-for-mcp/list-stuck-scheduled`, the site introspection abilities `webmastery-site-toolkit-for-mcp/get-site-info`, `webmastery-site-toolkit-for-mcp/get-user-info`, and `webmastery-site-toolkit-for-mcp/get-environment-info`, the user access audit ability `webmastery-site-toolkit-for-mcp/user-access-audit`, the Yoast score and metadata abilities `webmastery-site-toolkit-for-mcp/get-seo-scores`, `webmastery-site-toolkit-for-mcp/get-readability-scores`, and `webmastery-site-toolkit-for-mcp/get-yoast-metadata`, the SEOPress metadata ability `webmastery-site-toolkit-for-mcp/get-seopress-metadata`, the webmaster verification ability `webmastery-site-toolkit-for-mcp/webmaster-verification-status`, the database health ability `webmastery-site-toolkit-for-mcp/database-health`, the performance status ability `webmastery-site-toolkit-for-mcp/performance-status`, the backup status ability `webmastery-site-toolkit-for-mcp/backup-status`, plus the plugin abilities `webmastery-site-toolkit-for-mcp/list-plugins`, `webmastery-site-toolkit-for-mcp/plugin-audit`, `webmastery-site-toolkit-for-mcp/activate-plugin`, and `webmastery-site-toolkit-for-mcp/deactivate-plugin`.
 
@@ -18,7 +20,7 @@ For abilities with role or capability restrictions, include both:
 
 ## What CI checks
 
-`scripts/e2e-test.sh` first runs `tests/e2e/ability-runner.php`, which:
+`scripts/e2e-test.sh contract` runs `tests/e2e/ability-runner.php`, which:
 
 1. Creates deterministic WordPress fixtures.
 2. Installs and activates the MCP Adapter, Yoast SEO, and SEOPress plugin dependencies.
@@ -29,7 +31,7 @@ For abilities with role or capability restrictions, include both:
 7. Executes every manifest case through `wp_get_ability()->execute()`.
 8. Writes `e2e-artifacts/e2e-summary.json` with coverage and result counts.
 
-The script then runs `tests/e2e/mcp-crud-runner.php`, which:
+`scripts/e2e-test.sh e2e` runs `tests/e2e/mcp-crud-runner.php`, which:
 
 1. Creates temporary Application Password credentials for the existing E2E editor and subscriber users.
 2. Initializes real MCP HTTP sessions against the MCP Adapter default server.
@@ -49,18 +51,27 @@ composer validate:e2e-manifest
 
 This validates manifest JSON structure, required fields, allowed roles, expected result values, labels, and assertion shapes. It cannot replace full E2E coverage because it does not bootstrap WordPress or compare the manifest to `wp_get_abilities()`.
 
-For full Docker E2E, either start Compose yourself and run:
+For Docker Ability Contract QA, either start Compose yourself and run:
 
 ```bash
 docker compose up -d
-composer e2e
+composer qa:contract
 docker compose down -v
 ```
 
-Or let the E2E script manage Compose:
+For Docker Full MCP E2E QA, either start Compose yourself and run:
 
 ```bash
-E2E_MANAGE_COMPOSE=1 composer e2e
+docker compose up -d
+composer qa:e2e
+docker compose down -v
+```
+
+Or let the Docker QA script manage Compose:
+
+```bash
+E2E_MANAGE_COMPOSE=1 composer qa:contract
+E2E_MANAGE_COMPOSE=1 composer qa:e2e
 ```
 
 Set `E2E_KEEP_COMPOSE=1` when you want to leave the containers running for debugging.
@@ -74,12 +85,14 @@ Set `MCP_CRUD_ENDPOINT` only when you need the secondary CRUD runner to target a
 PowerShell users can run:
 
 ```powershell
+powershell -ExecutionPolicy Bypass -File scripts/qa-local.ps1 -Contract
 powershell -ExecutionPolicy Bypass -File scripts/qa-local.ps1 -E2E
 ```
 
 Unix, macOS, and Git Bash users can run:
 
 ```bash
+scripts/qa-local.sh --contract
 scripts/qa-local.sh --e2e
 ```
 

--- a/tests/unit/PostsHelpersTest.php
+++ b/tests/unit/PostsHelpersTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class PostsHelpersTest extends TestCase {
+
+	private static function call_private( string $method, array $args = array() ) {
+		$reflection = new ReflectionMethod( Webmastery_MCP_Posts::class, $method );
+		$reflection->setAccessible( true );
+		return $reflection->invokeArgs( null, $args );
+	}
+
+	public function test_validate_post_meta_key_rejects_empty_key(): void {
+		$result = self::call_private( 'validate_post_meta_key', array( '' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_meta_key', $result->get_error_code() );
+	}
+
+	public function test_validate_post_meta_key_accepts_valid_key(): void {
+		$result = self::call_private( 'validate_post_meta_key', array( 'Meta_Key-1:seo.title' ) );
+
+		$this->assertSame( 'Meta_Key-1:seo.title', $result );
+	}
+
+	public function test_normalize_meta_value_rejects_structured_values_for_scalar_meta(): void {
+		$result = self::call_private( 'normalize_meta_value', array( array( 'not' => 'scalar' ) ) );
+
+		$this->assertNull( $result );
+	}
+
+	public function test_normalize_meta_value_handles_boolean_storage_formats(): void {
+		$this->assertSame( '1', self::call_private( 'normalize_meta_value', array( true, 'boolean_string' ) ) );
+		$this->assertSame( '0', self::call_private( 'normalize_meta_value', array( false, 'boolean_string' ) ) );
+		$this->assertSame( 'yes', self::call_private( 'normalize_meta_value', array( true, 'seopress_boolean_string' ) ) );
+		$this->assertSame( '', self::call_private( 'normalize_meta_value', array( false, 'seopress_boolean_string' ) ) );
+	}
+
+	public function test_error_response_shape_is_stable(): void {
+		$response = self::call_private(
+			'error_response',
+			array(
+				'forbidden',
+				'Nope.',
+				array( 'capability' => 'edit_post' ),
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'success' => false,
+				'error'   => array(
+					'code'    => 'forbidden',
+					'message' => 'Nope.',
+				),
+				'data'    => array(
+					'capability' => 'edit_post',
+				),
+			),
+			$response
+		);
+	}
+}

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+define( 'ABSPATH', dirname(__DIR__, 2) . '/' );
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		private string $code;
+		private string $message;
+		private array $data;
+
+		public function __construct( string $code = '', string $message = '', array $data = array() ) {
+			$this->code    = $code;
+			$this->message = $message;
+			$this->data    = $data;
+		}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+
+		public function get_error_data(): array {
+			return $this->data;
+		}
+	}
+}
+
+function is_wp_error( $value ): bool {
+	return $value instanceof WP_Error;
+}
+
+function sanitize_key( $key ): string {
+	$key = strtolower( (string) $key );
+	return preg_replace( '/[^a-z0-9_\-]/', '', $key ) ?? '';
+}
+
+function sanitize_text_field( $value ): string {
+	$value = (string) $value;
+	$value = strip_tags( $value );
+	$value = preg_replace( '/[\r\n\t ]+/', ' ', $value ) ?? '';
+	return trim( $value );
+}
+
+function sanitize_textarea_field( $value ): string {
+	return trim( strip_tags( (string) $value ) );
+}
+
+function absint( $value ): int {
+	return max( 0, abs( (int) $value ) );
+}
+
+function rest_sanitize_boolean( $value ): bool {
+	if ( is_bool( $value ) ) {
+		return $value;
+	}
+
+	if ( is_string( $value ) ) {
+		return in_array( strtolower( $value ), array( '1', 'true', 'yes', 'on' ), true );
+	}
+
+	return (bool) $value;
+}
+
+function esc_url_raw( $url ): string {
+	$url = trim( (string) $url );
+	if ( '' === $url ) {
+		return '';
+	}
+
+	return filter_var( $url, FILTER_VALIDATE_URL ) ? $url : '';
+}
+
+require_once dirname(__DIR__, 2) . '/includes/class-posts.php';


### PR DESCRIPTION
## Summary

This PR moves the local QA/release hardening work onto a dedicated branch for merge prep.

It adds a layered QA strategy, separates GitHub Actions into Static QA, Unit Tests, Docker Ability Contract QA, Full MCP E2E QA, and Release Package QA, and centralizes release package build/validation through reusable scripts. It also adds PHPUnit/PHPStan setup, a small unit-test scaffold for post helper behavior, and updates contributor/repository documentation to match the new QA lanes.

## Why

The repo had grown enough QA and release surface area that one broad E2E lane was doing too much. Splitting the layers makes failures easier to understand, keeps fast PR checks fast, and gives releases a package-focused validation path before publishing.

## Local validation

- `composer install --no-interaction --prefer-dist --no-progress` passed.
- `composer qa` passed: PHP lint, PHPCS, PHPStan, Composer audit, E2E manifest validation, `git diff --check`, and PHPUnit.
- `bash scripts/release-qa.sh` passed locally, including release package validation, Ability Contract QA, and WordPress Plugin Check against the built package.
- `powershell -ExecutionPolicy Bypass -File scripts/qa-local.ps1 -E2E` passed locally, including Full MCP E2E QA with 9 protocol-level checks.

## Notes

Plugin Check still reports the known project warnings for plugin updater detection and Yoast SEO meta queries. The command exited successfully, and those warnings are consistent with the existing documented release-readiness posture.