### PR TITLE
chore: release v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Repository, CI, contributor, and GitHub platform changes are tracked separately 
 
 ## Unreleased
 
+## 2.4.0
+
 ### Added
 
 - Added expanded Yoast SEO free metadata coverage for canonical URLs, breadcrumb titles, Schema.org page/article types, Open Graph and Twitter metadata, primary category, robots directives, inclusive-language score inspection, generated Yoast head inspection, and deeper sitemap index diagnostics.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 Use it to let an agent draft or update content, manage media and comments, inspect site health, review SEO metadata, audit plugins and users, and gather safe site context without handing your personal admin account to the agent.
 
-> This README describes the current GitHub repo, including unreleased `main` branch work. The latest stable plugin header and WordPress.org `readme.txt` stable tag remain `2.3.0`; see [CHANGELOG.md](CHANGELOG.md) for what is released versus unreleased.
+> This README describes the current GitHub repo. The latest stable plugin header and WordPress.org `readme.txt` stable tag are `2.4.0`; see [CHANGELOG.md](CHANGELOG.md) for release notes.
 
 <table>
 <tr><td align="center"><strong>Without this plugin</strong><br/><img src="assets/before.png" alt="Before"></td>

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: mcp, ai, automation, content-management, artificial-intelligence
 Requires at least: 6.9
 Tested up to: 7.0
 Requires PHP: 8.0
-Stable tag: 2.3.0
+Stable tag: 2.4.0
 License: GPL-2.0+
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Donate link: https://paypal.me/VirtuallyBoring
@@ -85,6 +85,10 @@ https://www.virtuallyboring.com/webmastery-site-toolkit-for-mcp/
 
 == Changelog ==
 
+= 2.4.0 =
+* Add expanded Yoast SEO free metadata coverage for canonical URLs, breadcrumb titles, Schema.org page/article types, Open Graph and Twitter metadata, primary category, robots directives, inclusive-language score inspection, generated Yoast head inspection, and deeper sitemap index diagnostics.
+* Add first-class SEOPress free metadata coverage for titles, descriptions, target keywords, canonical URLs, Open Graph and Twitter/X metadata, primary category, robots directives, breadcrumb titles, read-only metadata inspection, and SEOPress-specific site overview diagnostics.
+
 = 2.3.0 =
 * Add public image URL uploads with URL safety checks, image MIME and upload-size enforcement, optional metadata, and optional featured-image assignment.
 * Add public Google/Bing webmaster verification checks without Google or Bing API credentials.
@@ -107,6 +111,9 @@ https://www.virtuallyboring.com/webmastery-site-toolkit-for-mcp/
 * Add block inspection, single-block replacement, and safer partial post body edits.
 
 == Upgrade Notice ==
+
+= 2.4.0 =
+Adds expanded Yoast SEO and SEOPress free metadata coverage, including richer social, robots, canonical, breadcrumb, Schema, read-only inspection, and site overview diagnostics.
 
 = 2.3.0 =
 Adds media URL uploads, webmaster verification checks, content hygiene diagnostics, CPT CRUD, post meta, revisions, comment replies/updates, and Administrator-only site audits.

--- a/webmastery-site-toolkit-for-mcp.php
+++ b/webmastery-site-toolkit-for-mcp.php
@@ -3,7 +3,7 @@
  * Plugin Name: Webmastery Site Toolkit for MCP
  * Plugin URI:  https://www.virtuallyboring.com/webmastery-site-toolkit-for-mcp/
  * Description: Adds site management abilities for MCP-powered WordPress workflows: posts, pages, taxonomy, comments, media, content hygiene, plugins, user lookup, site info, health, performance, backups, security, and SEO analysis.
- * Version:     2.3.0
+ * Version:     2.4.0
  * Requires at least: 6.9
  * Requires PHP: 8.0
  * Author:      Daniel Boring


### PR DESCRIPTION
## Summary
- Bump the plugin header and WordPress.org stable tag to 2.4.0
- Move the Yoast SEO and SEOPress metadata changelog entries into the 2.4.0 release section
- Add readme changelog and upgrade notice entries for 2.4.0

## Validation
- Release workflow for tag `v2.4.0` completed successfully and published the release asset
- `git diff --check` passed locally

Note: Local `composer phpcs` and E2E manifest validation could not run because PHP and Composer are not installed in this environment.