### PR TITLE
chore: release v2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Repository, CI, contributor, and GitHub platform changes are tracked separately 
 
 ## Unreleased
 
+## 2.4.1
+
 ### Changed
 
 - Hardened post, page, custom post type, media, and SEO score list abilities so returned items and totals only include objects the caller can access for the requested status, including private and trashed content.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: mcp, ai, automation, content-management, artificial-intelligence
 Requires at least: 6.9
 Tested up to: 7.0
 Requires PHP: 8.0
-Stable tag: 2.4.0
+Stable tag: 2.4.1
 License: GPL-2.0+
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Donate link: https://paypal.me/VirtuallyBoring
@@ -87,7 +87,7 @@ https://www.virtuallyboring.com/webmastery-site-toolkit-for-mcp/
 
 == Changelog ==
 
-= Unreleased =
+= 2.4.1 =
 * Harden permission callbacks and per-object filtering for posts, pages, custom post types, media, SEO score lists, plugin activation/deactivation, and runtime environment details.
 * Require publish capabilities for private/scheduled/published status changes and bulk publishing.
 * Reduce sensitive identity and fingerprinting fields in low-privilege responses.
@@ -119,7 +119,7 @@ https://www.virtuallyboring.com/webmastery-site-toolkit-for-mcp/
 
 == Upgrade Notice ==
 
-= Unreleased =
+= 2.4.1 =
 Permission hardening reduces low-privilege visibility into private/trash content, runtime versions, and sensitive identity fields. Use Administrator credentials for environment details and plugin management.
 
 = 2.4.0 =

--- a/webmastery-site-toolkit-for-mcp.php
+++ b/webmastery-site-toolkit-for-mcp.php
@@ -3,7 +3,7 @@
  * Plugin Name: Webmastery Site Toolkit for MCP
  * Plugin URI:  https://www.virtuallyboring.com/webmastery-site-toolkit-for-mcp/
  * Description: Adds site management abilities for MCP-powered WordPress workflows: posts, pages, taxonomy, comments, media, content hygiene, plugins, user lookup, site info, health, performance, backups, security, and SEO analysis.
- * Version:     2.4.0
+ * Version:     2.4.1
  * Requires at least: 6.9
  * Requires PHP: 8.0
  * Author:      Daniel Boring


### PR DESCRIPTION
## Summary
- Bump plugin header version and readme stable tag to 2.4.1.
- Move the permission-hardening release notes from Unreleased into 2.4.1 sections in CHANGELOG.md and readme.txt.

## Release process
- Release automation is tag-driven via `v2.4.1` after this PR merges.
- The premature local tag push was canceled and removed before publication because main requires PR changes.

## Local QA
- `composer validate:e2e-manifest`
- `composer phpcs`
- `composer qa:unit`
- `git diff --check`
- Manual package validation with Windows PHP: `php scripts/create-release-zip.php ...` + `php scripts/validate-release-package.php webmastery-site-toolkit-for-mcp-2.4.1.zip 2.4.1`

## Local limitations
- `bash scripts/release-qa.sh 2.4.1` could not complete locally because Bash/WSL cannot access Docker and the script falls into its Docker zip fallback. The tag workflow should run authoritative release QA on GitHub Actions.