### PR TITLE
Mature WordPress.org QA strategy

### DIFF
--- a/.github/AUTOMATION.md
+++ b/.github/AUTOMATION.md
@@ -1,18 +1,19 @@
 # GitHub Actions Automation Guide
 
-This repository uses GitHub Actions for five QA layers plus tag-based release publishing. See [`docs/qa-strategy.md`](../docs/qa-strategy.md) for the teaching-oriented strategy guide and branch-protection recommendations.
+This repository uses GitHub Actions for layered WordPress.org plugin QA plus tag-based release publishing. See [`docs/qa-strategy.md`](../docs/qa-strategy.md) for the teaching-oriented strategy guide, security QA policy, compatibility policy, and branch-protection recommendations.
 
 ## Trigger map (event -> workflow -> behavior)
 
 | Event | Workflow file | Behavior |
 |------|------|------|
-| `pull_request` (`opened`, `synchronize`, `reopened`) | `.github/workflows/coding-standards.yml` | Runs Static QA on every PR. |
-| `pull_request` (`opened`, `synchronize`, `reopened`) | `.github/workflows/unit-tests.yml` | Runs PHPUnit unit tests on every PR. |
-| `pull_request` (`opened`, `synchronize`, `reopened`) | `.github/workflows/e2e-qa.yml` | Detects runtime-impacting files, then runs Ability Contract QA and Full MCP E2E QA when in scope. |
-| release-impacting `pull_request` or `workflow_dispatch` | `.github/workflows/release-package-qa.yml` | Builds and validates the release package without publishing a GitHub release. |
-| `push` to `main` or `develop` | Static, unit, and Docker QA workflows | Re-runs the appropriate checks after merge. |
+| `pull_request` (`opened`, `synchronize`, `reopened`) | `.github/workflows/coding-standards.yml` | Runs `1 - Static QA` on every PR. |
+| `pull_request` (`opened`, `synchronize`, `reopened`) | `.github/workflows/unit-tests.yml` | Runs `2 - Unit Tests` on every PR. |
+| `pull_request` (`opened`, `synchronize`, `reopened`) | `.github/workflows/e2e-qa.yml` | Detects runtime-impacting files, then runs `3 - Ability Contract QA` and `4 - Full MCP E2E QA` when in scope. |
+| release-impacting `pull_request` or `workflow_dispatch` | `.github/workflows/release-package-qa.yml` | Runs `5 - Release Package QA` without publishing a GitHub release. |
+| `schedule` or `workflow_dispatch` | `.github/workflows/compatibility-qa.yml` | Runs `6 - Compatibility QA` against the primary and floating-latest Docker stacks. |
+| `push` to `main` or `develop` | Static, unit, and Docker QA workflows | Re-runs the appropriate numbered checks after merge. |
 | `workflow_dispatch` | Static, unit, Docker, or release workflows | Runs the selected QA layer on demand. |
-| `push` tag `v*` | `.github/workflows/release.yml` | Runs Release Package QA, then publishes a GitHub release. |
+| `push` tag `v*` | `.github/workflows/release.yml` | Runs `5 - Release Package QA`, including contract and transport Docker QA, then publishes a GitHub release. |
 
 ## Workflow details
 
@@ -39,12 +40,14 @@ This repository uses GitHub Actions for five QA layers plus tag-based release pu
 - CI fails when registered abilities are not covered by the manifest.
 - CI fails when manifest entries reference abilities that are no longer registered.
 - For permission-sensitive abilities, include both allowed and denied role cases where practical.
+- Security-sensitive abilities must keep negative cases and sensitive-field absence assertions required by `composer validate:security-qa`.
 - See `tests/e2e/README.md` for the manifest format and update rules.
 
 **Security model**
 - E2E execution jobs run with read-only permissions.
 - PR commenting is isolated to a dedicated job with comment-only write scope and no repository checkout.
 - Actions are pinned to immutable SHAs.
+- Static QA blocks risky `permission_callback => '__return_true'` ability registrations unless they are explicitly reviewed and allow-listed.
 
 ### Release (`release.yml`)
 
@@ -52,7 +55,7 @@ This repository uses GitHub Actions for five QA layers plus tag-based release pu
 1. Trigger on tag push matching `v*`.
 2. Validate `tag version == plugin header version == readme stable tag`.
 3. Verify plugin release notes exist in `readme.txt` for the tagged version.
-4. Run `scripts/release-qa.sh` to build the plugin ZIP, validate required/forbidden contents, and run WordPress Plugin Check against the built package.
+4. Run `scripts/release-qa.sh` to run contract and transport Docker QA, build the plugin ZIP, validate required/forbidden contents, and run WordPress Plugin Check against the built package.
 5. Fail if a release for the same tag already exists.
 6. Publish release with notes from `readme.txt`.
 
@@ -75,4 +78,6 @@ The E2E bootstrap installs and activates Yoast SEO and SEOPress from WordPress.o
 
 ## Branch protection recommendation
 
-Require Static QA and Unit Tests before every merge. Require Ability Contract QA and Full MCP E2E QA before merging runtime-impacting PRs.
+Require `1 - Static QA` and `2 - Unit Tests` before every merge. Require `3 - Ability Contract QA` and `4 - Full MCP E2E QA` before merging runtime-impacting PRs.
+
+Keep `6 - Compatibility QA` scheduled/manual until the matrix is stable enough to promote selected jobs to branch protection.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,11 +9,12 @@
 
 ## Testing
 <!-- How did you verify this works? Include local QA commands such as composer qa, scripts/qa-local.sh --contract, scripts/qa-local.sh --e2e, scripts/qa-local.ps1 -Contract, scripts/qa-local.ps1 -E2E, or scripts/qa-local.ps1 -PreflightOnly, plus any manual ability calls and what they returned. See docs/qa-strategy.md for which command fits each change type. -->
-<!-- Static QA and Unit Tests run automatically on every PR. Docker QA runs automatically for runtime-impacting changes. -->
+<!-- 1 - Static QA and 2 - Unit Tests run automatically on every PR. 3 - Ability Contract QA and 4 - Full MCP E2E QA run automatically for runtime-impacting changes. -->
 
 ## Checklist
 - [ ] Capability checks use the narrowest relevant WordPress capability and return/surface `WP_Error` on failure
 - [ ] List/query abilities filter returned objects with object/status-aware checks and do not leak unauthorized totals or sensitive identity fields
+- [ ] Security-sensitive abilities include allowed and denied E2E manifest cases, plus `assert_missing_paths` for fields hidden from lower-privilege callers
 - [ ] Inputs are sanitized or validated (`sanitize_text_field`, `sanitize_key`, `absint`, `wp_kses_post`, enum validation, or an equivalent WordPress API)
 - [ ] Ability responses follow the existing success/error shape for the affected ability group
 - [ ] New ability names use the `webmastery-site-toolkit-for-mcp/` prefix and set accurate `annotations` (`readonly`, `destructive`, `idempotent`)
@@ -22,5 +23,6 @@
 - [ ] Plugin-facing changes update `CHANGELOG.md` under `## Unreleased`
 - [ ] Repository, CI, contributor, GitHub platform, template, or agent workflow changes update `.github/REPOSITORY_CHANGELOG.md` under `## Unreleased`
 - [ ] Local QA checked with `composer qa` and the relevant Docker/release QA wrapper from `docs/qa-strategy.md`, or the missing tool/blocker is documented above
+- [ ] Compatibility QA was considered for release candidates, dependency-sensitive changes, or WordPress/PHP support changes
 - [ ] WordPress.org Detailed Plugin Guidelines were considered for public-facing or release-impacting changes such as naming, readme text, privacy/external calls, licensing, bundled assets, and release packaging
 - [ ] E2E QA is passing, or failures are unrelated and explained above

--- a/.github/REPOSITORY_CHANGELOG.md
+++ b/.github/REPOSITORY_CHANGELOG.md
@@ -9,7 +9,7 @@ Plugin-facing release notes belong in `CHANGELOG.md`.
 ### Added
 
 - Added E2E manifest fixtures and missing-path assertions for permission hardening coverage, including filtered private/trash list results and sensitive identity-field absence checks.
-- Added a five-layer QA strategy guide, PHPUnit/PHPStan QA commands, unit-test scaffolding, and separate GitHub Actions lanes for Static QA, Unit Tests, Ability Contract QA, Full MCP E2E QA, and Release Package QA.
+- Added a layered QA strategy guide, PHPUnit/PHPStan QA commands, unit-test scaffolding, and separate GitHub Actions lanes for Static QA, Unit Tests, Ability Contract QA, Full MCP E2E QA, and Release Package QA.
 - Added environment-specific QA notes for GitHub Actions, Windows PowerShell, and Windows Git Bash.
 - Added secondary in-depth E2E CRUD QA that exercises real MCP Adapter HTTP JSON-RPC sessions against the default server.
 - Added E2E manifest coverage for expanded Yoast SEO metadata writes and the read-only Yoast metadata inspection ability.
@@ -19,11 +19,16 @@ Plugin-facing release notes belong in `CHANGELOG.md`.
 - Added local QA preflight-only modes and clearer missing-tool guidance for PHP, Composer, Docker, and Bash prerequisites.
 - Added manifest E2E setup support for temporarily overriding active plugins in scoped ability cases.
 - Added cross-platform local QA helper scripts, a Composer QA command, and a lightweight E2E manifest validator for contributor preflight checks.
+- Added security QA policy validation for risky ability permission callbacks and permission-hardening manifest coverage.
+- Added scheduled/manual Compatibility QA for primary and floating-latest WordPress Docker stacks.
 - Added a dedicated Coding Standards workflow that installs Composer dev dependencies and runs PHPCS on pushes, pull requests, and manual dispatches.
 - Added an E2E mu-plugin fixture for custom post type ability coverage.
 
 ### Changed
 
+- Numbered the GitHub Actions workflow and job display names with `# -` prefixes so required checks align with the QA strategy guide.
+- Matured the QA strategy for the approved WordPress.org plugin by documenting security-sensitive ability coverage, compatibility triage, stricter debug-log expectations, and release transport coverage.
+- Updated Release Package QA to run both Ability Contract QA and Full MCP E2E QA before package validation and Plugin Check.
 - Expanded the QA strategy guide with a phased execution appendix for aligning existing commands, hardening fast checks, deepening Docker coverage, adding compatibility checks, scaling E2E maintainability, and introducing advanced quality signals.
 - Updated E2E PR comments to replace static success bullets with runtime-derived run facts, case pass/fail counts, debug-log status, changed files, and separate PR-head/tested-merge commit SHAs.
 - Updated E2E runner behavior so local runs can optionally manage Docker Compose startup and cleanup while preserving CI behavior.

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -1,4 +1,4 @@
-name: Static QA
+name: 1 - Static QA
 
 on:
   workflow_dispatch:
@@ -9,6 +9,7 @@ on:
 
 jobs:
   static-qa:
+    name: 1 - Static QA
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/compatibility-qa.yml
+++ b/.github/workflows/compatibility-qa.yml
@@ -1,0 +1,62 @@
+name: 6 - Compatibility QA
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 9 * * 1'
+
+jobs:
+  compatibility-qa:
+    name: 6 - Compatibility QA (${{ matrix.label }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: primary
+            wordpress-image: wordpress:7.0-php8.2-apache
+            mysql-image: mysql:8.0.36
+          - label: floating-latest-php
+            wordpress-image: wordpress:php8.3-apache
+            mysql-image: mysql:8.0.36
+    permissions:
+      contents: read
+    env:
+      COMPOSE_PROJECT_NAME: webmastery-site-toolkit-for-mcp-compat-${{ matrix.label }}-${{ github.run_id }}
+      MYSQL_IMAGE: ${{ matrix.mysql-image }}
+      MYSQL_PORT: 0
+      WORDPRESS_IMAGE: ${{ matrix.wordpress-image }}
+      WORDPRESS_PORT: 0
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          fetch-depth: 1
+
+      - name: Run compatibility Docker QA
+        env:
+          E2E_MANAGE_COMPOSE: 1
+          E2E_KEEP_COMPOSE: 1
+        run: bash scripts/e2e-test.sh all
+
+      - name: Collect failure artifacts
+        if: failure()
+        shell: bash
+        run: |
+          mkdir -p e2e-artifacts
+          docker compose logs --no-color > e2e-artifacts/docker-compose.log || true
+          docker compose exec -T wordpress cat /var/www/html/wp-content/debug.log > e2e-artifacts/wordpress-debug.log 2>/dev/null || true
+
+      - name: Clean up
+        if: always()
+        run: docker compose down -v --remove-orphans
+
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: compatibility-failure-artifacts-${{ matrix.label }}
+          path: e2e-artifacts/
+          if-no-files-found: ignore

--- a/.github/workflows/e2e-qa.yml
+++ b/.github/workflows/e2e-qa.yml
@@ -1,4 +1,4 @@
-name: Docker QA
+name: 3-4 - Docker QA
 
 on:
   workflow_dispatch:
@@ -9,6 +9,7 @@ on:
 
 jobs:
   changes:
+    name: Detect Docker QA changes
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -65,6 +66,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   ability-contract-qa:
+    name: 3 - Ability Contract QA
     needs: changes
     if: needs.changes.outputs.should-run == 'true'
     runs-on: ubuntu-latest
@@ -163,7 +165,7 @@ jobs:
             exit 0
           fi
           docker compose exec -T wordpress cat /var/www/html/wp-content/debug.log
-          if docker compose exec -T wordpress grep -Eiq 'fatal error|parse error|uncaught|error' /var/www/html/wp-content/debug.log; then
+          if docker compose exec -T wordpress grep -Eiq 'fatal error|parse error|uncaught|php (fatal error|parse error|warning|notice|deprecated)|deprecated|warning|notice|error' /var/www/html/wp-content/debug.log; then
             echo "status=error_entries_found" >> "$GITHUB_OUTPUT"
             exit 1
           fi
@@ -190,6 +192,7 @@ jobs:
           if-no-files-found: ignore
 
   full-mcp-e2e-qa:
+    name: 4 - Full MCP E2E QA
     needs: changes
     if: needs.changes.outputs.should-run == 'true'
     runs-on: ubuntu-latest
@@ -238,6 +241,7 @@ jobs:
           if-no-files-found: ignore
 
   comment-pr:
+    name: Docker QA PR comment
     needs: [changes, ability-contract-qa, full-mcp-e2e-qa]
     if: github.event_name == 'pull_request' && needs.changes.outputs.should-run == 'true' && always()
     runs-on: ubuntu-latest
@@ -311,6 +315,7 @@ jobs:
           gh api "repos/$OWNER/$REPO/issues/$ISSUE_NUMBER/comments" --method POST -f body="$BODY"
 
   skip-summary:
+    name: Docker QA skip summary
     needs: changes
     if: needs.changes.outputs.should-run != 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/release-package-qa.yml
+++ b/.github/workflows/release-package-qa.yml
@@ -1,4 +1,4 @@
-name: Release Package QA
+name: 5 - Release Package QA
 
 on:
   workflow_dispatch:
@@ -7,18 +7,23 @@ on:
     paths:
       - '.github/workflows/release.yml'
       - '.github/workflows/release-package-qa.yml'
+      - 'docker-compose.yml'
+      - 'scripts/e2e-test.sh'
       - 'scripts/build-release.sh'
       - 'scripts/release-qa.sh'
       - 'scripts/validate-release-package.php'
+      - 'tests/e2e/**'
       - 'webmastery-site-toolkit-for-mcp.php'
+      - 'includes/**'
       - 'readme.txt'
       - 'CHANGELOG.md'
       - 'LICENSE'
 
 jobs:
   release-package-qa:
+    name: 5 - Release Package QA
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 55
     permissions:
       contents: read
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: 5 - Release
 
 on:
   push:
@@ -7,7 +7,9 @@ on:
 
 jobs:
   release:
+    name: 5 - Publish Release
     runs-on: ubuntu-latest
+    timeout-minutes: 55
     permissions:
       contents: write
 
@@ -78,7 +80,7 @@ jobs:
           echo "version=$TAG_VERSION" >> "$GITHUB_OUTPUT"
           echo "notes-file=$NOTES_FILE" >> "$GITHUB_OUTPUT"
 
-      - name: Run Release Package QA
+      - name: Run 5 - Release Package QA
         run: bash scripts/release-qa.sh "${{ steps.validate.outputs.version }}"
 
       - name: Create GitHub Release

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,4 +1,4 @@
-name: Unit Tests
+name: 2 - Unit Tests
 
 on:
   workflow_dispatch:
@@ -9,6 +9,7 @@ on:
 
 jobs:
   unit-tests:
+    name: 2 - Unit Tests
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,7 @@ This plugin follows [WordPress Coding Standards](https://developer.wordpress.org
 
 - **Sanitize inputs** — use `sanitize_text_field()` for strings, `absint()` for IDs, `wp_kses_post()` for HTML content, and enum validation for fixed-value fields
 - **Capability checks** — every ability must have a `permission_callback` that returns a `WP_Error` on failure, not just `false`; prefer object-specific checks such as `edit_post` / `delete_post` when an object ID is available, and make list/query abilities filter each returned object plus totals before exposing full details
+- **Security-sensitive abilities** — include allowed and denied manifest cases for abilities that expose private data, user identity, environment/plugin details, destructive actions, uploads, or status transitions; use `assert_missing_paths` when lower-privilege responses must hide fields
 - **Prefer WordPress APIs** — use WordPress API functions (`get_posts()`, `wp_insert_post()`, etc.) for normal reads and writes. Direct `$wpdb` reads are limited to administrator-only diagnostics such as database health checks, must be prepared where variables are present, and must surface query errors.
 - **No output buffering** — abilities return arrays or `WP_Error` objects; the MCP Adapter handles serialization
 - **WordPress.org readiness** — avoid trademark-confusing names, spammy readme text, undisclosed external calls, bundled duplicate libraries, and non-GPL-compatible assets
@@ -54,7 +55,7 @@ composer install
 composer qa
 ```
 
-`composer qa` runs the normal fast pre-PR checks: Static QA plus Unit Tests. See [`docs/qa-strategy.md`](docs/qa-strategy.md) for the full QA posture, including when to run Ability Contract QA, Full MCP E2E QA, and Release Package QA.
+`composer qa` runs the normal fast pre-PR checks: Static QA plus Unit Tests. See [`docs/qa-strategy.md`](docs/qa-strategy.md) for the full QA posture, including when to run Ability Contract QA, Full MCP E2E QA, Release Package QA, and Compatibility QA.
 
 ---
 
@@ -125,11 +126,12 @@ Environment-specific notes for GitHub Actions, Windows PowerShell, and Windows G
 | Command | What it runs |
 | --- | --- |
 | `composer qa` | Fast local default: Static QA plus Unit Tests |
-| `composer qa:static` | PHP lint, PHPCS, PHPStan, Composer audit, manifest structure validation, and `git diff --check` |
+| `composer qa:static` | PHP lint, PHPCS, PHPStan, Composer audit, manifest structure validation, security QA validation, and `git diff --check` |
 | `composer qa:unit` | PHPUnit unit tests |
+| `composer validate:security-qa` | Static security QA policy checks for risky permission callbacks and required permission-hardening manifest cases |
 | `composer qa:contract` | Docker Ability Contract QA against an already-running Compose stack |
 | `composer qa:e2e` | Docker Full MCP E2E QA against an already-running Compose stack |
-| `composer qa:release` | Release Package QA, including built package validation and WordPress Plugin Check |
+| `composer qa:release` | Release Package QA, including Docker contract/transport QA, built package validation, and WordPress Plugin Check |
 | `E2E_MANAGE_COMPOSE=1 composer qa:contract` | Ability Contract QA with automatic Compose startup and cleanup |
 | `E2E_MANAGE_COMPOSE=1 composer qa:e2e` | Full MCP E2E QA with automatic Compose startup and cleanup |
 | `scripts/qa-local.sh --contract` | Unix/Git Bash wrapper for Composer QA plus managed Ability Contract QA |
@@ -201,7 +203,8 @@ Release checklist:
 4. Update `Stable tag`, plugin changelog entries, and upgrade notice in `readme.txt`.
 5. Confirm the generated zip uses the `webmastery-site-toolkit-for-mcp` directory slug.
 6. Run the official WordPress Plugin Check utility against the generated `webmastery-site-toolkit-for-mcp` package and confirm there are no unexpected errors.
-7. Tag and push `vX.Y.Z` to trigger the release workflow.
+7. Review the latest scheduled/manual `6 - Compatibility QA` result for upstream WordPress/PHP/plugin dependency drift.
+8. Tag and push `vX.Y.Z` to trigger the release workflow.
 
 ---
 
@@ -212,7 +215,7 @@ Release checklist:
 3. Add release notes to `readme.txt` under `== Changelog ==` and `== Upgrade Notice ==`
 4. Commit: `git commit -m "chore: release v1.x.x"`
 5. Tag and push: `git tag v1.x.x && git push origin v1.x.x`
-6. GitHub Actions builds the zip and creates the release automatically
+6. GitHub Actions runs contract, transport, package, and Plugin Check validation, then creates the release automatically
 7. Download the zip from the release and verify Plugin Check evaluates it as the `webmastery-site-toolkit-for-mcp` slug
 8. Upload the verified package to the WordPress.org SVN
 

--- a/composer.json
+++ b/composer.json
@@ -34,13 +34,15 @@
 			"@phpstan",
 			"@audit:locked",
 			"@validate:e2e-manifest",
+			"@validate:security-qa",
 			"@diff-check"
 		],
 		"qa:unit": "php vendor/phpunit/phpunit/phpunit --configuration=phpunit.xml.dist",
 		"test": [
 			"@qa:unit"
 		],
-		"validate:e2e-manifest": "php scripts/validate-e2e-manifest.php"
+		"validate:e2e-manifest": "php scripts/validate-e2e-manifest.php",
+		"validate:security-qa": "php scripts/validate-security-qa.php"
 	},
 	"config": {
 		"allow-plugins": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   mysql:
-    image: mysql:8.0.36
+    image: ${MYSQL_IMAGE:-mysql:8.0.36}
     environment:
       MYSQL_DATABASE: wordpress
       MYSQL_USER: wp
@@ -14,7 +14,7 @@ services:
       retries: 10
 
   wordpress:
-    image: wordpress:7.0-php8.2-apache
+    image: ${WORDPRESS_IMAGE:-wordpress:7.0-php8.2-apache}
     depends_on:
       mysql:
         condition: service_healthy

--- a/docs/qa-strategy.md
+++ b/docs/qa-strategy.md
@@ -1,18 +1,46 @@
 # QA Strategy
 
-This repository uses QA as a set of layered confidence checks. Each layer answers a different question, from "does the PHP parse?" to "can a real MCP client change WordPress content through the adapter?"
+This repository uses layered QA for a public WordPress.org plugin. The goal is to catch the cheapest problems first, then add WordPress runtime, MCP transport, security, compatibility, and release-package evidence when a change can affect users, site data, permissions, or publishing.
 
-The goal is not to run every expensive check for every typo. The goal is to run the cheapest useful checks first, then run Docker and release checks when a change can affect runtime behavior or shipping.
+The plugin is now reviewed as a WordPress.org plugin, so QA must prove more than "the code runs." It must also prove ability permissions, object-level access, response privacy, WordPress compatibility, and package contents stay aligned with WordPress.org expectations.
 
-## The five QA layers
+## QA checks
 
-| Layer | Command | What it proves | When it should run |
+| GitHub Actions check | Command | What it proves | When it should run |
 | --- | --- | --- | --- |
-| Static QA | `composer qa:static` | PHP files parse, WordPress Coding Standards pass, PHPStan can analyze the plugin at the configured level, Composer dependencies have no known locked advisories, the E2E manifest is structurally valid, and the diff has no whitespace errors. | Every PR and every push to `main`. |
-| Unit Tests | `composer qa:unit` | Small pieces of PHP logic behave correctly without booting WordPress. These tests are the fast safety net for sanitization, response shape, and helper behavior. | Every PR and every push to `main`. |
-| Ability Contract QA | `composer qa:contract` or `bash scripts/e2e-test.sh contract` | WordPress boots in Docker, required plugins load, every registered ability is represented in `tests/e2e/abilities-manifest.json`, manifest cases execute through `wp_get_ability()->execute()`, and the debug log stays clean. | Runtime PRs, `main`, releases, and manual dispatch. |
-| Full MCP E2E QA | `composer qa:e2e` or `bash scripts/e2e-test.sh e2e` | A real MCP HTTP JSON-RPC session can discover and execute abilities through the MCP Adapter, including editor CRUD and subscriber denial. | Runtime PRs, `main`, releases, and manual dispatch. |
-| Release Package QA | `composer qa:release` or `bash scripts/release-qa.sh` | The version metadata is aligned, the release zip contains only packaged plugin files, and WordPress Plugin Check evaluates the built package instead of the development checkout. | Release PRs, tags, and manual dispatch. |
+| 1 - Static QA | `composer qa:static` | PHP files parse, WordPress Coding Standards pass, PHPStan can analyze the plugin at the configured level, Composer dependencies have no known locked advisories, the E2E manifest is structurally valid, security-sensitive QA policy checks pass, and the diff has no whitespace errors. | Every PR and every push to `main`. |
+| 2 - Unit Tests | `composer qa:unit` | Small pieces of PHP logic behave correctly without booting WordPress. These tests are the fast safety net for sanitization, response shape, permission helpers, SEO metadata normalization, taxonomy helpers, plugin safety logic, and failure paths. | Every PR and every push to `main`. |
+| 3 - Ability Contract QA | `composer qa:contract` or `bash scripts/e2e-test.sh contract` | WordPress boots in Docker, required plugins load, every registered ability is represented in `tests/e2e/abilities-manifest.json`, manifest cases execute through `wp_get_ability()->execute()`, permission-sensitive cases pass, and the debug log stays clean. | Runtime PRs, ability PRs, security-sensitive PRs, `main`, releases, and manual dispatch. |
+| 4 - Full MCP E2E QA | `composer qa:e2e` or `bash scripts/e2e-test.sh e2e` | A real MCP HTTP JSON-RPC session can discover and execute abilities through the MCP Adapter, including Application Password authentication, session setup, tool discovery, editor CRUD, and subscriber denial. | Runtime PRs, ability PRs, security-sensitive PRs, `main`, releases, and manual dispatch. |
+| 5 - Release Package QA | `composer qa:release` or `bash scripts/release-qa.sh` | Release metadata is aligned, Ability Contract QA and Full MCP E2E QA pass, the release zip contains only packaged plugin files, and WordPress Plugin Check evaluates the built package instead of the development checkout. | Release PRs, tags, and manual dispatch. |
+| 6 - Compatibility QA | `.github/workflows/compatibility-qa.yml` | Scheduled/manual Docker QA against the primary stack and a floating-latest PHP/WordPress image catches upstream drift in WordPress, PHP, MCP Adapter, Yoast SEO, SEOPress, and Plugin Check dependencies. | Weekly schedule, manual dispatch, release-candidate investigation, and upstream-breakage triage. |
+
+## Security QA policy
+
+Security QA is a cross-cutting gate, not just a separate scanner. The permission issue fixed in PR #90 showed that valid syntax, WPCS, and broad ability coverage are not enough unless the tests explicitly prove the permission model.
+
+For every new or changed `webmastery-site-toolkit-for-mcp/*` ability, review whether it is security-sensitive. An ability is security-sensitive when it does any of the following:
+
+- reads private, draft, pending, scheduled, trashed, user, environment, plugin, security, database, backup, or performance data
+- returns full object payloads, totals, author identity, login names, emails, backend versions, filesystem/plugin details, or other fingerprinting data
+- creates, updates, deletes, publishes, schedules, privates, restores, activates, deactivates, uploads, or otherwise changes site state
+- accepts object IDs, URLs, HTML, metadata keys, taxonomy terms, plugin identifiers, statuses, or role/capability-sensitive inputs
+
+Security-sensitive abilities must include:
+
+1. A positive manifest case for a role/capability that should be allowed.
+2. A negative manifest case for a role/capability that should be denied, unless the ability intentionally returns public-safe data and that rationale is documented.
+3. Object/status-aware assertions for list/query abilities that can return mixed authorization results.
+4. `assert_missing_paths` for sensitive fields that must not appear for lower-privilege callers.
+5. Failure-path assertions for status escalation, protected metadata, unsafe URLs, ambiguous identifiers, stale preconditions, and destructive actions where applicable.
+
+`composer validate:security-qa` enforces the current high-risk policy:
+
+- `permission_callback => '__return_true'` is blocked in plugin ability registrations unless intentionally allow-listed in the validator after explicit security review.
+- The permission-hardening regression cases from PR #90 must keep negative manifest coverage.
+- Sensitive identity and fingerprinting absence assertions must remain in the manifest.
+
+This validator is intentionally conservative. It should catch known dangerous patterns without replacing human review, WordPress.org review, or future deeper static analysis such as CodeQL or Semgrep.
 
 ## Ability Contract QA vs Full MCP E2E QA
 
@@ -22,44 +50,41 @@ Ability Contract QA is the plugin contract layer. It asks: "Inside WordPress, di
 
 Full MCP E2E QA is the real transport layer. It asks: "Can an MCP client actually talk to WordPress through the MCP Adapter and perform real work?" It is narrower but deeper, because it uses Application Passwords, MCP session initialization, `tools/list`, ability discovery, and real CRUD calls over HTTP JSON-RPC.
 
-Both layers matter. Contract QA catches broad ability drift. Full MCP E2E catches transport and integration problems that direct PHP execution cannot see.
+Both layers matter. Contract QA catches broad ability drift and permission regressions. Full MCP E2E catches transport and integration problems that direct PHP execution cannot see.
 
-## Possible future advanced QA layer
+## Trigger matrix
 
-An advanced MCP manifest replay layer could exercise selected or all `tests/e2e/abilities-manifest.json` cases through the real MCP Adapter HTTP JSON-RPC transport instead of direct `wp_get_ability()->execute()` calls.
+| Event or change type | 1 - Static QA | 2 - Unit Tests | 3 - Ability Contract QA | 4 - Full MCP E2E QA | 5 - Release Package QA | 6 - Compatibility QA |
+| --- | --- | --- | --- | --- | --- | --- |
+| Docs-only PR | Required | Required | Skipped unless manually dispatched | Skipped unless manually dispatched | Skipped | Skipped |
+| Runtime PR | Required | Required | Required | Required | Skipped unless release-impacting | Manual when compatibility-risky |
+| New or changed ability | Required | Required | Required | Required | Skipped unless release-impacting | Manual when dependency/version-risky |
+| Security-sensitive PR | Required | Required | Required | Required | Required when release-bound | Manual before release when risk is broad |
+| Push to `main` | Required | Required | Required when runtime files changed | Required when runtime files changed | Skipped | Scheduled/manual |
+| Release PR | Required | Required | Required | Required | Required | Manual for release candidates |
+| Tag `v*` | Covered by release workflow setup and prior PR checks | Covered by prior PR checks | Covered by Release Package QA | Covered by Release Package QA | Required | Covered by scheduled/manual release-candidate run |
+| `workflow_dispatch` | Runs selected workflow | Runs selected workflow | Runs | Runs | Runs | Runs |
+| Weekly schedule | Skipped | Skipped | Skipped | Skipped | Skipped | Runs |
 
-This would answer a stronger question than the current Full MCP E2E QA: "Can the same ability cases that pass inside WordPress also pass when invoked by a real MCP client through `mcp-adapter-execute-ability`?"
-
-This should remain separate from the default Full MCP E2E QA unless the project needs deeper transport coverage. Replaying the full manifest over MCP would be slower and more brittle than Ability Contract QA, and it would duplicate much of the same behavioral coverage. A future implementation could use a dedicated command such as `composer qa:mcp-manifest` or `bash scripts/e2e-test.sh mcp-manifest`, with options to run a focused subset for changed abilities and a full replay for release candidates or manual investigations.
-
-## GitHub Actions trigger matrix
-
-| Event or change type | Static QA | Unit Tests | Ability Contract QA | Full MCP E2E QA | Release Package QA |
-| --- | --- | --- | --- | --- | --- |
-| Docs-only PR | Required | Required | Skipped unless manually dispatched | Skipped unless manually dispatched | Skipped |
-| Runtime PR | Required | Required | Required | Required | Skipped unless release-impacting |
-| Push to `main` | Required | Required | Required when runtime files changed | Required when runtime files changed | Skipped |
-| Release PR | Required | Required | Required | Required | Required |
-| Tag `v*` | Optional through previous PR checks | Optional through previous PR checks | Covered by release QA | Covered by release QA | Required |
-| `workflow_dispatch` | Runs selected workflow | Runs selected workflow | Runs | Runs | Runs |
-
-Runtime-impacting paths include plugin source, tests, scripts, Docker configuration, Composer files, workflow files, package metadata, and `readme.txt`.
+Runtime-impacting paths include plugin source, tests, scripts, Docker configuration, Composer files, workflow files, package metadata, assets, and `readme.txt`.
 
 ## Branch protection recommendation
 
 Require these checks before merging any PR:
 
-- `Static QA`
-- `Unit Tests`
+- `1 - Static QA`
+- `2 - Unit Tests`
 
-Require these checks before merging runtime-impacting PRs:
+Require these checks before merging runtime-impacting, ability, or security-sensitive PRs:
 
-- `Ability Contract QA`
-- `Full MCP E2E QA`
+- `3 - Ability Contract QA`
+- `4 - Full MCP E2E QA`
 
 Require release/package QA before publishing a release:
 
-- `Release Package QA`
+- `5 - Release Package QA`
+
+Use `6 - Compatibility QA` as a scheduled/manual maintainer gate at first. Promote individual compatibility jobs to required only after they are stable and low-noise.
 
 The important GitHub concept is "required status checks." A workflow can run on many events, but branch protection decides which successful checks are required before a PR can merge.
 
@@ -87,14 +112,23 @@ E2E_MANAGE_COMPOSE=1 composer qa:contract
 E2E_MANAGE_COMPOSE=1 composer qa:e2e
 ```
 
+For a security-sensitive change:
+
+```bash
+composer qa
+composer validate:security-qa
+E2E_MANAGE_COMPOSE=1 composer qa:contract
+E2E_MANAGE_COMPOSE=1 composer qa:e2e
+```
+
 For release preparation:
 
 ```bash
 composer qa
-E2E_MANAGE_COMPOSE=1 composer qa:contract
-E2E_MANAGE_COMPOSE=1 composer qa:e2e
 composer qa:release
 ```
+
+`composer qa:release` runs the Docker contract and transport checks before Plugin Check. If Docker is unavailable locally, use GitHub Actions for the authoritative release validation and document the local blocker in the PR.
 
 PowerShell users can use the local wrapper:
 
@@ -114,6 +148,33 @@ scripts/qa-local.sh --e2e
 scripts/qa-local.sh --release
 ```
 
+## WordPress.org release-readiness policy
+
+Before publishing a WordPress.org-facing release:
+
+1. Confirm version metadata matches across the plugin header, `readme.txt` stable tag, changelog, release notes, zip name, and tag.
+2. Run `composer qa` and `composer qa:release`.
+3. Confirm Plugin Check evaluates the built package under the canonical `webmastery-site-toolkit-for-mcp` slug.
+4. Confirm no unexpected WordPress debug-log warnings, notices, deprecations, or errors appear during Docker QA.
+5. Confirm security-sensitive changes have manifest evidence for allowed and denied access.
+6. Run or review the latest `6 - Compatibility QA` result before uploading a release candidate to WordPress.org.
+7. Document any known Plugin Check warnings or unavailable local tooling in the PR.
+
+## Compatibility policy
+
+The default PR path should stay stable and reasonably fast. Compatibility QA starts as scheduled/manual coverage because upstream images, plugin versions, and dependency repositories can change independently of a PR.
+
+The current compatibility workflow runs:
+
+- the primary Docker stack used by default QA
+- a floating-latest WordPress image on a newer PHP runtime
+
+When compatibility failures occur, triage them as:
+
+- **release blocker** when the failure affects the supported primary stack or a supported WordPress/PHP combination
+- **upstream drift** when a floating-latest dependency changed and the plugin needs an adjustment or documented compatibility boundary
+- **workflow maintenance** when the failure is caused by runner/image/tooling changes unrelated to plugin behavior
+
 ## Environment notes
 
 The QA layers are the same in every environment, but the safest entrypoint differs by shell.
@@ -122,7 +183,7 @@ The QA layers are the same in every environment, but the safest entrypoint diffe
 
 GitHub Actions is the authoritative validation gate before merge. The workflows install their own PHP and Composer runtime, use Ubuntu shell tools, and run Docker jobs on GitHub-hosted Linux runners.
 
-Use branch protection to require the relevant workflow checks instead of relying only on a contributor's local machine. At minimum, require Static QA and Unit Tests for every PR. For runtime-impacting PRs, require Ability Contract QA and Full MCP E2E QA.
+Use branch protection to require the relevant workflow checks instead of relying only on a contributor's local machine.
 
 ### Windows PowerShell
 
@@ -157,104 +218,16 @@ Docker Desktop must be running before Docker QA can start. WordPress, MCP Adapte
 
 Local Plugin Check output may include known warnings that are acceptable for this project. The release process should treat unexpected errors as blockers, while the documented warnings in `CONTRIBUTING.md` remain known review items.
 
-## Execution appendix
-
-Use this appendix to sequence QA improvements without turning every PR into a large infrastructure change. Each phase should land as a small PR with updated commands, workflows, documentation, and repository changelog entries.
-
-### Phase 0: keep the strategy and implementation aligned
-
-Before adding new QA depth, confirm the documented layers match the commands and workflows that exist in the repository.
-
-1. Reconcile release coverage: either make `scripts/release-qa.sh` run Full MCP E2E QA or update the trigger matrix so tag releases do not claim Full MCP E2E is covered by release QA.
-2. Keep `composer.json`, `scripts/qa-local.sh`, `scripts/qa-local.ps1`, GitHub Actions, and this document in sync whenever a QA command is renamed or split.
-3. Keep `.github/PULL_REQUEST_TEMPLATE.md` and `CONTRIBUTING.md` aligned with the QA commands contributors are expected to run.
-
-Exit criteria:
-
-- The command table, trigger matrix, local wrapper flags, and CI workflow names describe the same QA layers.
-- A maintainer can follow the release-preparation commands without needing undocumented steps.
-
-### Phase 1: harden the fast checks
-
-The fast checks should catch syntax, standards, type, dependency, and small helper regressions before Docker starts.
-
-1. Expand unit coverage beyond the initial helper tests to cover sanitization, response shape helpers, SEO metadata normalization, plugin safety logic, taxonomy helpers, and permission-denial result shapes.
-2. Add focused tests for failure paths, not only happy paths: invalid IDs, unsupported enum values, protected meta keys, ambiguous block targets, missing plugins, and denied capabilities.
-3. Raise PHPStan strictness gradually. Start from the current baseline, fix high-signal findings, then increase levels only when the new level is practical for day-to-day PRs.
-4. Consider adding CodeQL or Semgrep as a separate security-analysis workflow once PHPStan and Composer audit are stable.
-
-Exit criteria:
-
-- `composer qa` stays fast enough for every PR.
-- Unit tests cover representative logic from multiple ability groups.
-- Static QA failures are actionable and do not rely on broad ignored-error lists.
-
-### Phase 2: deepen Docker contract and transport coverage
-
-The Docker layers should prove WordPress integration and MCP transport behavior without duplicating every assertion in every layer.
-
-1. Keep Ability Contract QA broad: every registered ability must have manifest coverage, with positive and negative cases where permissions apply.
-2. Keep Full MCP E2E QA narrow but deep: it should prove real MCP Adapter session setup, tool discovery, ability execution, side effects, and denied-role propagation.
-3. Add the optional MCP manifest replay layer only when the project needs stronger transport coverage for selected abilities. Prefer focused replay for changed abilities and reserve full replay for release candidates or manual investigations.
-4. Improve artifacts by writing machine-readable summaries for both contract and transport runs, and upload them on failure.
-
-Exit criteria:
-
-- Contract failures identify ability, role, expected result, and assertion context.
-- Transport failures identify the MCP phase that failed: initialize, tools/list, discover, execute, side effect, denial, or cleanup.
-- Full MCP manifest replay remains optional and does not slow the default PR path.
-
-### Phase 3: add compatibility and dependency confidence
-
-Compatibility checks should run where they add signal without blocking routine PRs for unrelated matrix noise.
-
-1. Add a scheduled or manual compatibility workflow for supported PHP versions, current and minimum supported WordPress versions, and relevant database variants.
-2. Keep the default PR path on the minimum supported PHP version plus the primary Docker stack so compatibility regressions are caught early without excessive runtime.
-3. Add a floating-latest scheduled run for WordPress, MCP Adapter, Yoast SEO, SEOPress, and Plugin Check so upstream changes are detected before release week.
-4. Document which compatibility failures are release blockers and which require triage before being made required checks.
-
-Exit criteria:
-
-- Required PR checks remain stable and reasonably fast.
-- Scheduled compatibility checks expose upstream or version-specific breakage with enough context to reproduce locally.
-
-### Phase 4: scale E2E maintainability
-
-As the ability count grows, split large E2E surfaces by purpose instead of making one monolithic runner absorb every case.
-
-1. Group manifest cases by ability domain, such as posts/pages, custom post types, taxonomy, media, comments, SEO, diagnostics, plugins, and site introspection.
-2. Add runner filters for ability group, ability name, or manifest label so maintainers can reproduce focused failures locally.
-3. Consider CI sharding only after group filters exist and the full contract run becomes slow enough to justify parallel jobs.
-4. Preserve a full contract run for release candidates and manual dispatch even if PR checks become selective.
-
-Exit criteria:
-
-- A maintainer can run one affected ability group locally without editing the manifest.
-- CI can report which ability group failed.
-- Full release coverage remains available.
-
-### Phase 5: add advanced quality signals only where they pay off
-
-Coverage and mutation metrics are useful when applied to security-sensitive or heavily reused logic, but they should not become vanity gates.
-
-1. Add coverage reporting for unit tests after the fast unit layer has meaningful breadth.
-2. Set thresholds only for critical helper areas that are stable enough to support thresholds.
-3. Consider mutation testing for sanitization, capability, and response-shape helpers if ordinary coverage stops finding meaningful gaps.
-4. Treat new metrics as advisory first, then promote them to required gates only after they are stable and low-noise.
-
-Exit criteria:
-
-- Coverage reports help guide missing tests rather than blocking unrelated work.
-- Mutation testing, if added, is scoped to high-value code and can run manually or on schedule.
-
 ## How to read failures
 
-Static QA failures usually mean the code has a syntax, style, static-analysis, manifest-shape, dependency-audit, or whitespace problem. Fix these first because they are the cheapest.
+Static QA failures usually mean the code has a syntax, style, static-analysis, manifest-shape, security-policy, dependency-audit, or whitespace problem. Fix these first because they are the cheapest.
 
 Unit test failures usually mean a small helper contract changed. Either fix the behavior or intentionally update the test if the contract changed.
 
-Ability Contract QA failures usually mean the plugin and manifest disagree, a permission case is wrong, an ability response shape changed, or WordPress logged an error.
+Ability Contract QA failures usually mean the plugin and manifest disagree, a permission case is wrong, an ability response shape changed, an expected sensitive field appeared, or WordPress logged a problem.
 
-Full MCP E2E failures usually mean the real MCP Adapter path broke: session setup, tool discovery, ability execution, WordPress side effects, or denied-role behavior.
+Full MCP E2E failures usually mean the real MCP Adapter path broke: session setup, tool discovery, ability execution, WordPress side effects, denied-role behavior, or cleanup.
 
-Release Package QA failures usually mean the package is not ready to ship: version metadata is out of sync, release notes are missing, dev files leaked into the zip, or Plugin Check found a WordPress.org readiness issue.
+Release Package QA failures usually mean the package is not ready to ship: Docker contract/transport checks failed, version metadata is out of sync, release notes are missing, dev files leaked into the zip, or Plugin Check found a WordPress.org readiness issue.
+
+Compatibility QA failures usually mean upstream WordPress, PHP, MySQL, MCP Adapter, Yoast SEO, SEOPress, Plugin Check, or GitHub runner behavior changed and needs maintainer triage.

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -196,8 +196,8 @@ run_debug_log_check() {
 	fi
 
 	compose exec -T wordpress bash -lc "cat /var/www/html/wp-content/debug.log"
-	if compose exec -T wordpress bash -lc "grep -Eiq 'fatal error|parse error|uncaught|error' /var/www/html/wp-content/debug.log"; then
-		echo "Debug log contains fatal/error-level entries"
+	if compose exec -T wordpress bash -lc "grep -Eiq 'fatal error|parse error|uncaught|php (fatal error|parse error|warning|notice|deprecated)|deprecated|warning|notice|error' /var/www/html/wp-content/debug.log"; then
+		echo "Debug log contains WordPress/PHP problem entries"
 		return 1
 	fi
 }

--- a/scripts/qa-local.sh
+++ b/scripts/qa-local.sh
@@ -16,7 +16,7 @@ Runs local preflight QA:
   - composer qa (static + unit)
   - optional Docker Ability Contract QA
   - optional Docker Full MCP E2E QA
-  - optional Release Package QA
+  - optional Release Package QA, including Docker contract/transport checks and Plugin Check
 
 Options:
   --contract        run managed Docker Ability Contract QA

--- a/scripts/release-qa.sh
+++ b/scripts/release-qa.sh
@@ -42,7 +42,7 @@ export E2E_MANAGE_COMPOSE=1
 export E2E_KEEP_COMPOSE=1
 trap 'docker compose down -v --remove-orphans >/dev/null 2>&1 || true' EXIT
 
-bash scripts/e2e-test.sh contract
+bash scripts/e2e-test.sh all
 docker compose exec -T wordpress wp --allow-root plugin install plugin-check --activate --force
 docker compose exec -T wordpress rm -rf "/var/www/html/wp-content/plugins/${PLUGIN_SLUG}-package"
 docker compose cp "build/${PLUGIN_SLUG}" "wordpress:/var/www/html/wp-content/plugins/${PLUGIN_SLUG}-package"

--- a/scripts/validate-security-qa.php
+++ b/scripts/validate-security-qa.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+$repo_root     = dirname(__DIR__);
+$includes_path = $repo_root . '/includes';
+$manifest_path = $repo_root . '/tests/e2e/abilities-manifest.json';
+$errors        = array();
+
+function webmastery_mcp_security_qa_fail( array $errors ): void {
+	foreach ( $errors as $error ) {
+		fwrite( STDERR, "ERROR {$error}\n" );
+	}
+
+	exit( 1 );
+}
+
+function webmastery_mcp_security_qa_read_json( string $path ): array {
+	$raw = file_get_contents( $path );
+	if ( false === $raw ) {
+		webmastery_mcp_security_qa_fail( array( "Could not read {$path}" ) );
+	}
+
+	$data = json_decode( $raw, true );
+	if ( JSON_ERROR_NONE !== json_last_error() || ! is_array( $data ) ) {
+		webmastery_mcp_security_qa_fail( array( "Invalid JSON in {$path}: " . json_last_error_msg() ) );
+	}
+
+	return $data;
+}
+
+function webmastery_mcp_security_qa_has_missing_path_case( array $cases, string $ability, array $paths ): bool {
+	foreach ( $cases as $case ) {
+		if ( ! is_array( $case ) || $ability !== ( $case['ability'] ?? '' ) ) {
+			continue;
+		}
+
+		$missing_paths = $case['assert_missing_paths'] ?? array();
+		if ( ! is_array( $missing_paths ) ) {
+			continue;
+		}
+
+		$has_all_paths = true;
+		foreach ( $paths as $path ) {
+			if ( ! in_array( $path, $missing_paths, true ) ) {
+				$has_all_paths = false;
+				break;
+			}
+		}
+
+		if ( $has_all_paths ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+function webmastery_mcp_security_qa_has_filtered_total_case( array $cases, string $ability, string $status ): bool {
+	foreach ( $cases as $case ) {
+		if ( ! is_array( $case ) || $ability !== ( $case['ability'] ?? '' ) ) {
+			continue;
+		}
+
+		if ( 'success' !== ( $case['expect'] ?? '' ) ) {
+			continue;
+		}
+
+		$input         = $case['input'] ?? array();
+		$assert_values = $case['assert_values'] ?? array();
+		if (
+			is_array( $input )
+			&& $status === ( $input['status'] ?? '' )
+			&& is_array( $assert_values )
+			&& array_key_exists( 'data.total', $assert_values )
+			&& 0 === $assert_values['data.total']
+		) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+if ( is_dir( $includes_path ) ) {
+	$iterator = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator( $includes_path, FilesystemIterator::SKIP_DOTS )
+	);
+
+	foreach ( $iterator as $file ) {
+		if ( ! $file->isFile() || 'php' !== $file->getExtension() ) {
+			continue;
+		}
+
+		$contents = file_get_contents( $file->getPathname() );
+		if ( false === $contents ) {
+			$errors[] = "Could not read {$file->getPathname()}";
+			continue;
+		}
+
+		if ( preg_match( "/['\"]permission_callback['\"]\\s*=>\\s*['\"]__return_true['\"]/", $contents ) ) {
+			$errors[] = "{$file->getPathname()} uses permission_callback => __return_true. Public ability callbacks require explicit security review and should be allow-listed in this validator only when intentionally unauthenticated.";
+		}
+	}
+}
+
+$manifest = webmastery_mcp_security_qa_read_json( $manifest_path );
+$summary  = array();
+
+foreach ( $manifest as $case ) {
+	if ( ! is_array( $case ) ) {
+		continue;
+	}
+
+	$ability = (string) ( $case['ability'] ?? '' );
+	$expect  = (string) ( $case['expect'] ?? '' );
+	if ( '' === $ability ) {
+		continue;
+	}
+
+	if ( ! isset( $summary[ $ability ] ) ) {
+		$summary[ $ability ] = array(
+			'success' => 0,
+			'failure' => 0,
+		);
+	}
+
+	if ( isset( $summary[ $ability ][ $expect ] ) ) {
+		$summary[ $ability ][ $expect ]++;
+	}
+}
+
+$required_failure_cases = array(
+	'webmastery-site-toolkit-for-mcp/activate-plugin',
+	'webmastery-site-toolkit-for-mcp/bulk-publish-posts',
+	'webmastery-site-toolkit-for-mcp/create-cpt-mcp-book',
+	'webmastery-site-toolkit-for-mcp/create-cpt-mcp-case-study',
+	'webmastery-site-toolkit-for-mcp/create-page',
+	'webmastery-site-toolkit-for-mcp/create-post',
+	'webmastery-site-toolkit-for-mcp/deactivate-plugin',
+	'webmastery-site-toolkit-for-mcp/get-environment-info',
+	'webmastery-site-toolkit-for-mcp/get-user',
+	'webmastery-site-toolkit-for-mcp/list-cpt-mcp-book',
+	'webmastery-site-toolkit-for-mcp/list-cpt-mcp-case-study',
+	'webmastery-site-toolkit-for-mcp/list-media',
+	'webmastery-site-toolkit-for-mcp/list-users',
+	'webmastery-site-toolkit-for-mcp/security-audit',
+	'webmastery-site-toolkit-for-mcp/update-cpt-mcp-book',
+	'webmastery-site-toolkit-for-mcp/update-cpt-mcp-case-study',
+	'webmastery-site-toolkit-for-mcp/update-page',
+	'webmastery-site-toolkit-for-mcp/update-post',
+);
+
+foreach ( $required_failure_cases as $ability ) {
+	if ( empty( $summary[ $ability ]['failure'] ) ) {
+		$errors[] = "{$ability} must keep at least one negative permission/security manifest case.";
+	}
+}
+
+foreach ( array( 'list-posts', 'list-pages' ) as $ability_slug ) {
+	$ability = "webmastery-site-toolkit-for-mcp/{$ability_slug}";
+	if ( ! webmastery_mcp_security_qa_has_filtered_total_case( $manifest, $ability, 'private' ) ) {
+		$errors[] = "{$ability} must keep a private-status filtered-total manifest case.";
+	}
+	if ( ! webmastery_mcp_security_qa_has_missing_path_case( $manifest, $ability, array( 'data.items.0.author_login' ) ) ) {
+		$errors[] = "{$ability} must keep an author_login absence assertion.";
+	}
+}
+
+if ( ! webmastery_mcp_security_qa_has_missing_path_case( $manifest, 'webmastery-site-toolkit-for-mcp/list-users', array( 'data.items.0.login', 'data.items.0.email' ) ) ) {
+	$errors[] = 'webmastery-site-toolkit-for-mcp/list-users must keep login/email absence assertions for lower-privilege user-listing cases.';
+}
+
+if ( ! webmastery_mcp_security_qa_has_missing_path_case( $manifest, 'webmastery-site-toolkit-for-mcp/get-user', array( 'data.login', 'data.email' ) ) ) {
+	$errors[] = 'webmastery-site-toolkit-for-mcp/get-user must keep login/email absence assertions for lower-privilege user-read cases.';
+}
+
+if ( ! webmastery_mcp_security_qa_has_missing_path_case( $manifest, 'webmastery-site-toolkit-for-mcp/get-site-info', array( 'data.wordpress_version', 'data.active_theme.version' ) ) ) {
+	$errors[] = 'webmastery-site-toolkit-for-mcp/get-site-info must keep version fingerprinting absence assertions for low-privilege cases.';
+}
+
+if ( $errors ) {
+	webmastery_mcp_security_qa_fail( $errors );
+}
+
+printf(
+	"PASS security QA policy: %d required negative-case abilities, sensitive-field absence assertions, and permission callback scan\n",
+	count( $required_failure_cases )
+);

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -18,6 +18,8 @@ For abilities with role or capability restrictions, include both:
 1. A positive case for a role that should be allowed.
 2. A negative case for a role that should be denied.
 
+For security-sensitive abilities, also include any assertions needed to prove the response does not leak data. Examples include `assert_missing_paths` for login names, emails, backend versions, protected metadata, private/trash totals, or other fields that lower-privilege users must not see. `composer validate:security-qa` enforces the current high-risk permission-hardening cases that protect against regressions like the WordPress.org review findings fixed in PR #90.
+
 ## What CI checks
 
 `scripts/e2e-test.sh contract` runs `tests/e2e/ability-runner.php`, which:
@@ -48,9 +50,10 @@ For quick local checks that do not require WordPress, run:
 
 ```bash
 composer validate:e2e-manifest
+composer validate:security-qa
 ```
 
-This validates manifest JSON structure, required fields, allowed roles, expected result values, labels, and assertion shapes. It cannot replace full E2E coverage because it does not bootstrap WordPress or compare the manifest to `wp_get_abilities()`.
+These commands validate manifest JSON structure, required fields, allowed roles, expected result values, labels, assertion shapes, required security-sensitive coverage, and risky static permission callback patterns. They cannot replace full E2E coverage because they do not bootstrap WordPress or compare the manifest to `wp_get_abilities()`.
 
 For Docker Ability Contract QA, either start Compose yourself and run:
 


### PR DESCRIPTION
## Summary
- add enforceable security QA validation for risky ability permission callbacks and permission-hardening manifest coverage
- add scheduled/manual Compatibility QA against primary and floating-latest Docker stacks
- update release QA to run both Ability Contract QA and Full MCP E2E QA before package validation and Plugin Check
- document the matured WordPress.org QA strategy, security-sensitive ability expectations, compatibility policy, and contributor checklist updates

## Testing
- `composer qa:static`
- `composer qa:unit`
- `composer phpcs`
- `composer validate:e2e-manifest`
- `composer validate:security-qa`
- `bash -n scripts/e2e-test.sh`
- `bash -n scripts/release-qa.sh`
- `bash -n scripts/qa-local.sh`
- `docker compose config --quiet`
- `git diff --check`
- `E2E_MANAGE_COMPOSE=1 bash scripts/e2e-test.sh all` via Bash-side env assignment: 81/81 abilities covered, 192/192 manifest cases passed, 83 negative cases, MCP CRUD 9/9 passed