### PR TITLE
Document repository governance strategies

### DIFF
--- a/.github/AUTOMATION.md
+++ b/.github/AUTOMATION.md
@@ -1,6 +1,6 @@
 # GitHub Actions Automation Guide
 
-This repository uses GitHub Actions for layered WordPress.org plugin QA plus tag-based release publishing. See [`docs/qa-strategy.md`](../docs/qa-strategy.md) for the teaching-oriented strategy guide, security QA policy, compatibility policy, and branch-protection recommendations.
+This repository uses GitHub Actions for layered WordPress.org plugin QA plus tag-based release publishing. See [`docs/ci-cd-strategy.md`](../docs/ci-cd-strategy.md) for the automation strategy, [`docs/qa-strategy.md`](../docs/qa-strategy.md) for QA evidence, [`docs/security-strategy.md`](../docs/security-strategy.md) for security policy, and [`docs/release-strategy.md`](../docs/release-strategy.md) for release governance.
 
 ## Trigger map (event -> workflow -> behavior)
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
 <!-- e.g. webmastery-site-toolkit-for-mcp/list-media — leave blank for bug fixes -->
 
 ## Testing
-<!-- How did you verify this works? Include local QA commands such as composer qa, scripts/qa-local.sh --contract, scripts/qa-local.sh --e2e, scripts/qa-local.ps1 -Contract, scripts/qa-local.ps1 -E2E, or scripts/qa-local.ps1 -PreflightOnly, plus any manual ability calls and what they returned. See docs/qa-strategy.md for which command fits each change type. -->
+<!-- How did you verify this works? Include local QA commands such as composer qa, scripts/qa-local.sh --contract, scripts/qa-local.sh --e2e, scripts/qa-local.ps1 -Contract, scripts/qa-local.ps1 -E2E, or scripts/qa-local.ps1 -PreflightOnly, plus any manual ability calls and what they returned. See docs/qa-strategy.md for which command fits each change type. For process-impacting changes, also check docs/ci-cd-strategy.md, docs/security-strategy.md, and docs/release-strategy.md. -->
 <!-- 1 - Static QA and 2 - Unit Tests run automatically on every PR. 3 - Ability Contract QA and 4 - Full MCP E2E QA run automatically for runtime-impacting changes. -->
 
 ## Checklist
@@ -24,5 +24,6 @@
 - [ ] Repository, CI, contributor, GitHub platform, template, or agent workflow changes update `.github/REPOSITORY_CHANGELOG.md` under `## Unreleased`
 - [ ] Local QA checked with `composer qa` and the relevant Docker/release QA wrapper from `docs/qa-strategy.md`, or the missing tool/blocker is documented above
 - [ ] Compatibility QA was considered for release candidates, dependency-sensitive changes, or WordPress/PHP support changes
-- [ ] WordPress.org Detailed Plugin Guidelines were considered for public-facing or release-impacting changes such as naming, readme text, privacy/external calls, licensing, bundled assets, and release packaging
+- [ ] CI/CD, security, or release process changes update the matching strategy document when policy changes
+- [ ] WordPress.org Detailed Plugin Guidelines were considered for public-facing or release-impacting changes such as naming, readme text, privacy/external calls, licensing, bundled assets, and release packaging; see `CONTRIBUTING.md`, `docs/security-strategy.md`, and `docs/release-strategy.md`
 - [ ] E2E QA is passing, or failures are unrelated and explained above

--- a/.github/REPOSITORY_CHANGELOG.md
+++ b/.github/REPOSITORY_CHANGELOG.md
@@ -8,6 +8,7 @@ Plugin-facing release notes belong in `CHANGELOG.md`.
 
 ### Added
 
+- Added CI/CD, security, and release strategy guides with official GitHub and WordPress references for maintainers operating the approved WordPress.org plugin.
 - Added E2E manifest fixtures and missing-path assertions for permission hardening coverage, including filtered private/trash list results and sensitive identity-field absence checks.
 - Added a layered QA strategy guide, PHPUnit/PHPStan QA commands, unit-test scaffolding, and separate GitHub Actions lanes for Static QA, Unit Tests, Ability Contract QA, Full MCP E2E QA, and Release Package QA.
 - Added environment-specific QA notes for GitHub Actions, Windows PowerShell, and Windows Git Bash.
@@ -26,6 +27,7 @@ Plugin-facing release notes belong in `CHANGELOG.md`.
 
 ### Changed
 
+- Expanded repo governance documentation so the official WordPress.org Detailed Plugin Guidelines are explicitly mapped to QA release readiness, security/privacy review, release strategy, contributor guidance, and PR review.
 - Numbered the GitHub Actions workflow and job display names with `# -` prefixes so required checks align with the QA strategy guide.
 - Matured the QA strategy for the approved WordPress.org plugin by documenting security-sensitive ability coverage, compatibility triage, stricter debug-log expectations, and release transport coverage.
 - Updated Release Package QA to run both Ability Contract QA and Full MCP E2E QA before package validation and Plugin Check.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,12 @@ composer qa
 
 `composer qa` runs the normal fast pre-PR checks: Static QA plus Unit Tests. See [`docs/qa-strategy.md`](docs/qa-strategy.md) for the full QA posture, including when to run Ability Contract QA, Full MCP E2E QA, Release Package QA, and Compatibility QA.
 
+The repo strategy docs explain how maintainers operate the project:
+
+- [`docs/ci-cd-strategy.md`](docs/ci-cd-strategy.md) covers GitHub Actions, branch protection, workflow permissions, scheduled checks, and artifact policy.
+- [`docs/security-strategy.md`](docs/security-strategy.md) covers ability permissions, sensitive data, dependency and secret handling, and vulnerability response.
+- [`docs/release-strategy.md`](docs/release-strategy.md) covers versioning, release readiness, GitHub releases, WordPress.org SVN publishing, hotfixes, and rollback policy.
+
 ---
 
 ## Adding a new ability
@@ -185,6 +191,16 @@ Before packaging a release for WordPress.org, maintainers compare the final plug
 - Use WordPress-bundled libraries instead of shipping duplicate copies.
 - Verify the `Version` header, `Stable tag`, changelog, release zip name, and top-level zip directory all describe the same release.
 
+Use this quick mapping when deciding whether a PR needs guideline review:
+
+| PR changes | Guideline concerns to review |
+| --- | --- |
+| Plugin name, slug, description, tags, screenshots, banners, or `readme.txt` | Trademarks/project names, readme spam, affiliate/service link disclosure, and public claims. |
+| Assets, bundled libraries, generated files, or build steps | GPL compatibility, human-readable source, public build instructions, and WordPress default library usage. |
+| External APIs, telemetry, remote requests, ads, credits, or SaaS integrations | Explicit consent, service documentation, privacy policy/readme disclosure, and no executable remote code. |
+| Admin notices, dashboards, settings pages, or upsell copy | No dashboard hijacking, notices are scoped/dismissible/actionable, and no misleading locked-feature or trialware behavior. |
+| Release metadata, package contents, tags, or SVN upload | Stable version availability, version increment, `Stable tag` alignment, descriptive SVN commits, and no rapid SVN churn. |
+
 ---
 
 ## Versioning policy
@@ -209,6 +225,8 @@ Release checklist:
 ---
 
 ## Release process (maintainers)
+
+See [`docs/release-strategy.md`](docs/release-strategy.md) for the complete release governance model and official GitHub/WordPress references.
 
 1. Update the `Version` header in `webmastery-site-toolkit-for-mcp.php`
 2. Move plugin-facing `CHANGELOG.md` notes from `## Unreleased` into the release version

--- a/docs/ci-cd-strategy.md
+++ b/docs/ci-cd-strategy.md
@@ -1,0 +1,104 @@
+# CI/CD Strategy
+
+This repository uses GitHub Actions as the automation layer for pull request checks, Docker WordPress validation, scheduled compatibility checks, and release publishing. The CI/CD strategy explains how automation is organized; the QA strategy explains what confidence each check provides.
+
+## Goals
+
+1. Keep the default pull request path fast enough for routine contribution.
+2. Require stronger evidence for runtime, ability, security-sensitive, and release-impacting changes.
+3. Keep workflow permissions narrow and explicit.
+4. Make every required status check name unique and stable for branch protection.
+5. Preserve enough artifacts and PR comments to debug failures without rerunning everything locally.
+
+## Workflow inventory
+
+| Workflow | Primary trigger | Purpose |
+| --- | --- | --- |
+| `1 - Static QA` | `pull_request`, `push`, `workflow_dispatch` | PHP lint, WPCS, PHPStan, Composer audit, E2E manifest validation, security QA validation, and diff whitespace checks. |
+| `2 - Unit Tests` | `pull_request`, `push`, `workflow_dispatch` | Fast PHPUnit helper tests. |
+| `3-4 - Docker QA` | `pull_request`, `push`, `workflow_dispatch` | Runtime-impact detection, Ability Contract QA, Full MCP E2E QA, failure artifacts, and PR comment summaries. |
+| `5 - Release Package QA` | release-impacting `pull_request`, `workflow_dispatch` | Contract + transport Docker QA, package validation, and WordPress Plugin Check without publishing. |
+| `5 - Release` | tag push `v*` | Validates release inputs, runs Release Package QA, and publishes the GitHub release. |
+| `6 - Compatibility QA` | weekly `schedule`, `workflow_dispatch` | Runs Docker QA against primary and floating-latest WordPress/PHP stacks. |
+
+## Pull request policy
+
+All pull requests should pass:
+
+1. `1 - Static QA`
+2. `2 - Unit Tests`
+
+Runtime, ability, and security-sensitive pull requests should also pass:
+
+1. `3 - Ability Contract QA`
+2. `4 - Full MCP E2E QA`
+
+Release-impacting pull requests should pass:
+
+1. `5 - Release Package QA`
+
+Compatibility QA starts as scheduled/manual. Promote matrix jobs to branch protection only after they are stable and low-noise.
+
+## Branch protection
+
+Branch protection should require unique status check names before merge. GitHub warns that duplicate job names across workflows can create ambiguous status checks, so workflow and job display names should remain stable and unique.
+
+Recommended `main` protection:
+
+1. Require pull request before merge.
+2. Require `1 - Static QA` and `2 - Unit Tests`.
+3. Require `3 - Ability Contract QA` and `4 - Full MCP E2E QA` for runtime-impacting PRs through process/checklist discipline.
+4. Require conversation resolution.
+5. Require linear history if repository settings continue to disallow merge commits.
+6. Do not allow force pushes or branch deletion.
+
+## Workflow permissions
+
+Use least privilege per job:
+
+- Read-only jobs use `contents: read`.
+- PR comment jobs use `pull-requests: write` and avoid checking out PR-controlled code.
+- Release publishing uses `contents: write` only in the tag release workflow.
+- Secrets should not be needed for PR validation from forks. If future workflows require secrets, use environments and reviewer gates.
+
+## Scheduling policy
+
+Scheduled jobs should detect drift that a PR did not cause:
+
+- `6 - Compatibility QA` runs weekly to catch upstream WordPress, PHP, MCP Adapter, Yoast SEO, SEOPress, Plugin Check, and Docker image changes.
+- Scheduled failures should create maintainer follow-up work only after triage confirms the failure is not transient infrastructure noise.
+- Compatibility failures are release blockers only when they affect the supported primary stack or a supported version combination.
+
+## Artifact and reporting policy
+
+Docker jobs should upload artifacts on failure:
+
+- Docker Compose logs
+- WordPress debug log
+- E2E summary JSON when available
+- MCP CRUD summary JSON when available
+
+PR comments should summarize runtime facts rather than static success claims:
+
+- tested commit
+- workflow run
+- ability coverage counts
+- pass/fail counts
+- debug-log status
+- tested WordPress/PHP/MySQL/plugin versions
+
+## Failure handling
+
+1. Fix `1 - Static QA` failures first; they are usually syntax, standards, static-analysis, security-policy, dependency, manifest, or whitespace issues.
+2. Fix `2 - Unit Tests` before Docker failures; unit failures often indicate helper contract drift.
+3. For Docker failures, inspect the PR comment and uploaded artifacts.
+4. For release failures, distinguish package metadata/content failures from Plugin Check failures.
+5. For scheduled compatibility failures, reproduce manually before changing required branch protection.
+
+## Official references
+
+- GitHub Docs: [Continuous integration](https://docs.github.com/en/actions/get-started/continuous-integration)
+- GitHub Docs: [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax)
+- GitHub Docs: [About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)
+- GitHub Docs: [Secure use reference](https://docs.github.com/en/actions/reference/security/secure-use)
+- GitHub Docs: [About releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases)

--- a/docs/qa-strategy.md
+++ b/docs/qa-strategy.md
@@ -4,6 +4,12 @@ This repository uses layered QA for a public WordPress.org plugin. The goal is t
 
 The plugin is now reviewed as a WordPress.org plugin, so QA must prove more than "the code runs." It must also prove ability permissions, object-level access, response privacy, WordPress compatibility, and package contents stay aligned with WordPress.org expectations.
 
+Related strategy guides:
+
+- [`ci-cd-strategy.md`](ci-cd-strategy.md) explains GitHub Actions automation, branch protection, workflow permissions, schedules, artifacts, and failure handling.
+- [`security-strategy.md`](security-strategy.md) explains the WordPress plugin threat model, ability permission policy, secrets, dependency security, and vulnerability response.
+- [`release-strategy.md`](release-strategy.md) explains versioning, release readiness, GitHub releases, WordPress.org SVN publishing, hotfixes, and rollback policy.
+
 ## QA checks
 
 | GitHub Actions check | Command | What it proves | When it should run |
@@ -157,8 +163,11 @@ Before publishing a WordPress.org-facing release:
 3. Confirm Plugin Check evaluates the built package under the canonical `webmastery-site-toolkit-for-mcp` slug.
 4. Confirm no unexpected WordPress debug-log warnings, notices, deprecations, or errors appear during Docker QA.
 5. Confirm security-sensitive changes have manifest evidence for allowed and denied access.
-6. Run or review the latest `6 - Compatibility QA` result before uploading a release candidate to WordPress.org.
-7. Document any known Plugin Check warnings or unavailable local tooling in the PR.
+6. Review the official [WordPress.org Detailed Plugin Guidelines](https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/) for release-impacting changes, especially licensing, bundled assets, external services, tracking consent, executable remote code, readme content, default WordPress libraries, SVN discipline, version increments, and trademarks.
+7. Run or review the latest `6 - Compatibility QA` result before uploading a release candidate to WordPress.org.
+8. Document any known Plugin Check warnings, guideline considerations, or unavailable local tooling in the PR.
+
+Plugin Check supports the guideline review, but it does not replace maintainer responsibility for the final WordPress.org package contents and behavior.
 
 ## Compatibility policy
 

--- a/docs/release-strategy.md
+++ b/docs/release-strategy.md
@@ -1,0 +1,115 @@
+# Release Strategy
+
+Release strategy explains how reviewed repository changes become a GitHub release and a WordPress.org plugin update. CI/CD strategy explains the automation mechanics; QA strategy explains the validation layers.
+
+## Release goals
+
+1. Ship only reviewed, tested, package-ready plugin files.
+2. Keep GitHub release artifacts, WordPress.org SVN state, plugin headers, `readme.txt`, and changelogs aligned.
+3. Avoid publishing a release until release package QA, Plugin Check, and security-sensitive validation pass.
+4. Make hotfixes fast without bypassing release safety checks.
+
+## Versioning policy
+
+This project uses semantic versioning:
+
+| Version part | Use for |
+| --- | --- |
+| Major | Breaking ability names, inputs, outputs, authentication/permission model, or MCP client compatibility. |
+| Minor | Backward-compatible abilities, features, compatibility support, or user-visible enhancements. |
+| Patch | Bug fixes, security fixes, packaging fixes, documentation corrections, and compatibility patches. |
+
+Security fixes can be patch releases when the public API remains compatible.
+
+## Release readiness checklist
+
+Before tagging a release:
+
+1. Choose the version bump.
+2. Update the plugin header `Version`.
+3. Update `readme.txt` `Stable tag`.
+4. Move plugin-facing notes from `CHANGELOG.md` `## Unreleased` into the release section.
+5. Add matching `readme.txt` changelog and upgrade notice entries.
+6. Keep repository-only notes in `.github/REPOSITORY_CHANGELOG.md`.
+7. Run or confirm `composer qa`.
+8. Run or confirm `composer qa:release`.
+9. Review the latest `6 - Compatibility QA` result for upstream drift.
+10. Confirm no unexpected Plugin Check findings remain.
+
+## GitHub release flow
+
+The tag workflow owns GitHub release creation:
+
+1. Maintainer pushes `vX.Y.Z`.
+2. `.github/workflows/release.yml` validates the tag, plugin header, stable tag, text domain, short description, release notes, and duplicate release state.
+3. `scripts/release-qa.sh` runs Ability Contract QA and Full MCP E2E QA, builds the release zip, validates package contents, and runs WordPress Plugin Check.
+4. GitHub release is created with the built zip and notes from `readme.txt`.
+
+Do not manually upload an unvalidated zip to GitHub releases.
+
+## WordPress.org release flow
+
+WordPress.org uses SVN as the release repository. GitHub remains the development repository.
+
+Recommended process:
+
+1. Download the GitHub release zip after the tag workflow passes.
+2. Inspect or extract the package if needed.
+3. Commit finished release files to WordPress.org SVN `trunk`.
+4. Copy or tag the release to the matching SVN `tags/X.Y.Z` path.
+5. Confirm `Stable tag` points to the intended release.
+6. Verify the WordPress.org plugin page updates as expected.
+
+Avoid frequent small SVN commits. WordPress.org guidance treats SVN as a release repository, not the day-to-day development repository.
+
+## WordPress.org guideline governance
+
+Before tagging or uploading a release, review the official Detailed Plugin Guidelines for the release diff and final package. For this repository, the highest-risk guideline areas are:
+
+| Guideline area | Repository implication |
+| --- | --- |
+| GPL compatibility and responsibility for contents | Confirm all bundled code, screenshots, images, fonts, and libraries are GPL-compatible and intentionally included in the release zip. |
+| Stable WordPress.org distribution | Keep the WordPress.org package current with released GitHub code; do not distribute a newer stable plugin only through alternate channels. |
+| Human-readable code and build tooling | Do not ship obfuscated code. If build tooling becomes necessary, keep source/build instructions public and maintained. |
+| External services and tracking consent | Document any external service dependency in `readme.txt` and require explicit consent before contacting external servers for tracking or non-essential functionality. |
+| Executable third-party code | Do not load executable plugin/theme/update code from non-WordPress.org systems; bundle non-service JavaScript and CSS locally. |
+| Readme and public-page hygiene | Keep `readme.txt` useful for people, avoid keyword stuffing, keep tags to five or fewer, and disclose any affiliate/service links. |
+| WordPress default libraries | Use WordPress-bundled libraries instead of shipping duplicate copies of libraries WordPress already provides. |
+| SVN release discipline | Treat SVN as the release repository, use descriptive commit messages, avoid rapid minor readme/package churn, and tag each release once ready. |
+| Version increments | Increment the plugin version for every user-facing release and keep the plugin header, `Stable tag`, changelog, Git tag, and SVN tag aligned. |
+| Trademarks and project names | Avoid names/slugs that imply ownership of WordPress, MCP Adapter, SEO plugins, or other third-party projects. |
+
+## Hotfix policy
+
+Use a hotfix release when a shipped version has a user-impacting bug, security issue, packaging error, or compatibility break.
+
+Hotfix steps:
+
+1. Branch from current `main`.
+2. Make the smallest safe fix.
+3. Add a regression test, manifest case, or security QA policy check when feasible.
+4. Run the normal release readiness checklist.
+5. Publish a patch version unless compatibility requires a larger version bump.
+6. Document the issue clearly in `CHANGELOG.md` and `readme.txt`.
+7. Use a GitHub security advisory when the fix addresses an exploitable vulnerability.
+
+## Rollback policy
+
+Prefer forward fixes over deleting or rewriting release history.
+
+If a release is bad:
+
+1. Stop promoting the release.
+2. Open a hotfix issue/PR immediately.
+3. If WordPress.org users are exposed to a severe issue, coordinate with WordPress.org plugin support/review channels.
+4. Publish a corrected patch release.
+5. Document what happened in maintainer-facing notes and, if user-facing, in release notes.
+
+## Official references
+
+- GitHub Docs: [About releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases)
+- GitHub Docs: [Repository security advisories](https://docs.github.com/en/code-security/concepts/vulnerability-reporting-and-management/repository-security-advisories)
+- WordPress Plugin Handbook: [Using Subversion](https://developer.wordpress.org/plugins/wordpress-org/how-to-use-subversion/)
+- WordPress Plugin Handbook: [Detailed Plugin Guidelines](https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/)
+- WordPress.org: [Plugin Check](https://wordpress.org/plugins/plugin-check/)
+- WordPress Plugin Handbook: [Plugin readmes](https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/)

--- a/docs/security-strategy.md
+++ b/docs/security-strategy.md
@@ -1,0 +1,100 @@
+# Security Strategy
+
+This repository is a public WordPress.org plugin that exposes MCP abilities. Security strategy focuses on preventing unsafe access to WordPress data and site-changing actions, while QA strategy defines the checks that prove the policy.
+
+## Security goals
+
+1. Use the narrowest relevant WordPress capability for every ability.
+2. Avoid exposing private content, trashed content, backend environment details, user identity fields, plugin details, or other sensitive data to lower-privilege users.
+3. Prevent status escalation such as publishing, scheduling, or making content private without the required capability.
+4. Keep ability `permission_callback` behavior aligned with execute-time checks.
+5. Treat dependency, workflow, and release automation as part of the security boundary.
+
+## Threat model
+
+Primary risks for this plugin:
+
+- authenticated low-privilege users invoking MCP abilities that reveal data they could not access in wp-admin
+- broad list abilities leaking private/trash content or unauthorized totals
+- write abilities bypassing object, publish, delete, plugin-management, or administrator capabilities
+- sensitive response fields exposing logins, emails, version fingerprints, plugin state, or environment details
+- unsafe URLs, uploads, protected metadata, or unvalidated identifiers crossing trust boundaries
+- compromised workflow tokens, leaked secrets, or vulnerable dependencies affecting release integrity
+
+## Ability permission policy
+
+Every ability must have an explicit `permission_callback`. Public `__return_true` callbacks are blocked by `composer validate:security-qa` unless intentionally allow-listed after explicit review.
+
+Use these defaults:
+
+| Ability type | Permission expectation |
+| --- | --- |
+| Public-safe read-only data | `read`, with documentation explaining why the response is safe. |
+| Object reads | Object-aware checks such as `read_post`, `edit_post`, or mapped CPT capabilities before returning full object payloads. |
+| List/query abilities | Query-level capability plus per-object/status filtering before normalizing results and totals. |
+| Writes and deletes | Object-specific `edit_*` / `delete_*` checks and status-specific publish/private/schedule checks. |
+| Plugin, environment, database, backup, performance, security, or runtime details | Administrator-level capabilities such as `manage_options` or plugin-management capabilities. |
+| User identity data | Restrict login/email fields to callers with user-management capabilities; use `assert_missing_paths` for lower-privilege cases. |
+
+## Security-sensitive test policy
+
+Security-sensitive abilities must have E2E manifest coverage showing both allowed and denied behavior. Add `assert_missing_paths` when a response should omit sensitive fields for lower-privilege users.
+
+Current static enforcement:
+
+- `composer validate:security-qa`
+- `composer validate:e2e-manifest`
+- `composer audit --locked`
+- `composer phpcs`
+- PHPStan at the configured project level
+
+Current runtime enforcement:
+
+- Ability Contract QA executes all manifest cases in WordPress.
+- Full MCP E2E verifies real MCP Adapter authentication, discovery, execution, and subscriber denial.
+- Docker QA fails when the WordPress debug log contains warnings, notices, deprecations, or errors.
+
+## Dependency and supply-chain policy
+
+- Composer dependencies are audited with `composer audit --locked`.
+- Dependency changes should be reviewed carefully in PRs.
+- Use GitHub Dependency Review or Dependabot features when available to prevent vulnerable dependencies from entering the repository.
+- Release workflows should build from the reviewed repository state and validate package contents before publishing.
+
+## Secrets and workflow security
+
+- Do not commit credentials, Application Passwords, tokens, SVN passwords, or service keys.
+- Prefer GitHub Actions `GITHUB_TOKEN` with explicit job-level `permissions`.
+- Do not expose secrets to workflows running untrusted PR code.
+- Rotate any secret that appears in logs or repository history.
+- Keep release credentials outside repository files; use GitHub secrets/environments if future automation requires them.
+
+## WordPress.org guideline security and privacy expectations
+
+The Detailed Plugin Guidelines make plugin developers responsible for all plugin contents and actions. For this MCP plugin, guideline review should be part of security review when a PR changes:
+
+- **External communication** — document required third-party services in `readme.txt`; do not contact external servers for tracking or non-essential functionality without explicit consent.
+- **Executable remote code** — do not load executable plugin, theme, update, JavaScript, or CSS code from third-party systems unless it is a documented service use that the guidelines allow.
+- **Public credits and links** — do not add public-facing "powered by" links, credits, or promotional output unless it is opt-in and disabled by default.
+- **Admin notices** — keep dashboard notices scoped, actionable, dismissible, and self-removing when resolved.
+- **Bundled assets and libraries** — ensure included code/assets are GPL-compatible and use WordPress-provided libraries instead of duplicating default libraries.
+- **Readme claims** — avoid unsupported security, compliance, legal, traffic, SEO, or automation guarantees in public-facing copy.
+
+## Vulnerability response
+
+1. Prefer private reporting for suspected exploitable vulnerabilities.
+2. Triage severity, affected versions, exploitability, and whether WordPress.org users are exposed.
+3. Fix on a private branch or security advisory fork when appropriate.
+4. Add regression tests or manifest cases that would have caught the issue.
+5. Release a patched version and publish advisory notes when needed.
+6. If the vulnerability affects a released package, coordinate WordPress.org plugin update timing and user communication.
+
+## Official references
+
+- GitHub Docs: [Repository security advisories](https://docs.github.com/en/code-security/concepts/vulnerability-reporting-and-management/repository-security-advisories)
+- GitHub Docs: [Secret scanning](https://docs.github.com/en/code-security/concepts/secret-security/secret-scanning)
+- GitHub Docs: [Dependency review](https://docs.github.com/en/code-security/concepts/supply-chain-security/dependency-review)
+- GitHub Docs: [Code scanning](https://docs.github.com/en/code-security/concepts/code-scanning/code-scanning)
+- GitHub Docs: [Secure use reference](https://docs.github.com/en/actions/reference/security/secure-use)
+- WordPress Developer Resources: [Security](https://developer.wordpress.org/apis/security/)
+- WordPress Plugin Handbook: [Detailed Plugin Guidelines](https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/)


### PR DESCRIPTION
## Summary
- Add CI/CD, security, and release strategy docs with official GitHub and WordPress references
- Map the WordPress.org Detailed Plugin Guidelines into QA release readiness, release governance, security/privacy review, contributor guidance, and PR review
- Update automation, contributor, QA strategy, PR template, and repository changelog references

## Testing
- `git diff origin/main...HEAD --check`
- `composer validate:e2e-manifest`
- `composer phpcs`