### PR TITLE
Add WordPress.org SVN release automation

### DIFF
--- a/.github/AUTOMATION.md
+++ b/.github/AUTOMATION.md
@@ -13,7 +13,7 @@ This repository uses GitHub Actions for layered WordPress.org plugin QA plus tag
 | `schedule` or `workflow_dispatch` | `.github/workflows/compatibility-qa.yml` | Runs `6 - Compatibility QA` against the primary and floating-latest Docker stacks. |
 | `push` to `main` or `develop` | Static, unit, and Docker QA workflows | Re-runs the appropriate numbered checks after merge. |
 | `workflow_dispatch` | Static, unit, Docker, or release workflows | Runs the selected QA layer on demand. |
-| `push` tag `v*` | `.github/workflows/release.yml` | Runs `5 - Release Package QA`, including contract and transport Docker QA, then publishes a GitHub release. |
+| `push` tag `v*` | `.github/workflows/release.yml` | Runs release validation and `5 - Release Package QA`, waits for protected `wordpress-org` approval, deploys to WordPress.org SVN, then publishes a GitHub release. |
 
 ## Workflow details
 
@@ -57,7 +57,15 @@ This repository uses GitHub Actions for layered WordPress.org plugin QA plus tag
 3. Verify plugin release notes exist in `readme.txt` for the tagged version.
 4. Run `scripts/release-qa.sh` to run contract and transport Docker QA, build the plugin ZIP, validate required/forbidden contents, and run WordPress Plugin Check against the built package.
 5. Fail if a release for the same tag already exists.
-6. Publish release with notes from `readme.txt`.
+6. Wait for approval in the protected `wordpress-org` GitHub Environment.
+7. Deploy `build/webmastery-site-toolkit-for-mcp` to WordPress.org SVN with `SLUG=webmastery-site-toolkit-for-mcp` and SVN tag `X.Y.Z`.
+8. Publish the GitHub release with the built ZIP and notes from `readme.txt`.
+
+**WordPress.org deployment**
+- The SVN deploy step uses `10up/action-wordpress-plugin-deploy` pinned to an immutable commit.
+- `SVN_USERNAME` and `SVN_PASSWORD` are read from GitHub Actions secrets. Prefer `wordpress-org` environment secrets; repository-level secrets can work as a fallback when the job is still environment-gated.
+- The workflow deploys code only. WordPress.org listing assets are intentionally deferred until a `.wordpress-org/` asset directory is added and reviewed.
+- WordPress.org SVN is production. Use release package QA, compatibility QA, and staging WordPress installs for test coverage rather than a separate WordPress.org test SVN.
 
 ## Issue and PR process
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,5 +25,6 @@
 - [ ] Local QA checked with `composer qa` and the relevant Docker/release QA wrapper from `docs/qa-strategy.md`, or the missing tool/blocker is documented above
 - [ ] Compatibility QA was considered for release candidates, dependency-sensitive changes, or WordPress/PHP support changes
 - [ ] CI/CD, security, or release process changes update the matching strategy document when policy changes
+- [ ] Release-impacting changes account for GitHub tag `vX.Y.Z`, WordPress.org SVN tag `X.Y.Z`, protected `wordpress-org` deployment approval, and package/readme/version alignment
 - [ ] WordPress.org Detailed Plugin Guidelines were considered for public-facing or release-impacting changes such as naming, readme text, privacy/external calls, licensing, bundled assets, and release packaging; see `CONTRIBUTING.md`, `docs/security-strategy.md`, and `docs/release-strategy.md`
 - [ ] E2E QA is passing, or failures are unrelated and explained above

--- a/.github/REPOSITORY_CHANGELOG.md
+++ b/.github/REPOSITORY_CHANGELOG.md
@@ -8,6 +8,7 @@ Plugin-facing release notes belong in `CHANGELOG.md`.
 
 ### Added
 
+- Added protected WordPress.org SVN deployment to the tag-based release workflow, including pinned action usage, GitHub Actions secret guidance, SemVer/SVN tag policy, and full release documentation coverage.
 - Added CI/CD, security, and release strategy guides with official GitHub and WordPress references for maintainers operating the approved WordPress.org plugin.
 - Added E2E manifest fixtures and missing-path assertions for permission hardening coverage, including filtered private/trash list results and sensitive identity-field absence checks.
 - Added a layered QA strategy guide, PHPUnit/PHPStan QA commands, unit-test scaffolding, and separate GitHub Actions lanes for Static QA, Unit Tests, Ability Contract QA, Full MCP E2E QA, and Release Package QA.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,15 @@ on:
       - 'v*'
 
 jobs:
-  release:
-    name: 5 - Publish Release
+  release-qa:
+    name: 5 - Validate Release
     runs-on: ubuntu-latest
     timeout-minutes: 55
     permissions:
-      contents: write
+      contents: read
+
+    outputs:
+      version: ${{ steps.validate.outputs.version }}
 
     steps:
       - name: Checkout
@@ -27,6 +30,8 @@ jobs:
 
       - name: Validate release inputs
         id: validate
+        env:
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
@@ -83,14 +88,77 @@ jobs:
       - name: Run 5 - Release Package QA
         run: bash scripts/release-qa.sh "${{ steps.validate.outputs.version }}"
 
+  publish:
+    name: 5 - Publish Release
+    needs: release-qa
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+    environment:
+      name: wordpress-org
+      url: https://wordpress.org/plugins/webmastery-site-toolkit-for-mcp/
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          fetch-depth: 1
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # 2.35.5
+        with:
+          php-version: '8.0'
+          coverage: none
+
+      - name: Prepare release artifacts
+        id: artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.release-qa.outputs.version }}"
+          ZIP_FILE="$(bash scripts/build-release.sh "$VERSION")"
+          NOTES_FILE="build/release-notes-${VERSION}.md"
+          NOTES="$(awk "/^= ${VERSION} =/{found=1; next} found && /^= /{exit} found{print}" readme.txt | sed '/^[[:space:]]*$/d')"
+
+          if [ -z "$NOTES" ]; then
+            echo "No plugin release notes found in readme.txt for version ${VERSION}" >&2
+            exit 1
+          fi
+
+          printf '%s\n' "$NOTES" > "$NOTES_FILE"
+          echo "zip-file=$ZIP_FILE" >> "$GITHUB_OUTPUT"
+          echo "notes-file=$NOTES_FILE" >> "$GITHUB_OUTPUT"
+
+      - name: Verify GitHub Release is unpublished
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          RELEASE_TAG="v${{ needs.release-qa.outputs.version }}"
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Release $RELEASE_TAG already exists; refusing duplicate publish" >&2
+            exit 1
+          fi
+
+      - name: Deploy to WordPress.org SVN
+        uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # 2.3.0
+        env:
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          SLUG: webmastery-site-toolkit-for-mcp
+          VERSION: ${{ needs.release-qa.outputs.version }}
+          BUILD_DIR: build/webmastery-site-toolkit-for-mcp
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
-          VERSION="${{ steps.validate.outputs.version }}"
+          VERSION="${{ needs.release-qa.outputs.version }}"
           gh release create "v${VERSION}" \
-            "webmastery-site-toolkit-for-mcp-${VERSION}.zip" \
+            "${{ steps.artifacts.outputs.zip-file }}" \
             --title "v${VERSION}" \
-            --notes-file "${{ steps.validate.outputs.notes-file }}"
+            --notes-file "${{ steps.artifacts.outputs.notes-file }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -211,6 +211,8 @@ This project follows **Semantic Versioning** (`MAJOR.MINOR.PATCH`):
 - **MINOR** (`1.X.0`) — new backward-compatible abilities or features.
 - **PATCH** (`1.4.X`) — backward-compatible bug fixes, security fixes, and documentation-only corrections.
 
+Git tags use `vX.Y.Z`. WordPress.org SVN tags use `X.Y.Z`. Every user-facing code release, including patch releases, should go through the protected WordPress.org SVN deployment path after release QA passes. Cosmetic readme or Plugin Directory asset updates do not require a code version bump.
+
 Release checklist:
 
 1. Choose the version bump based on the rules above.
@@ -220,7 +222,9 @@ Release checklist:
 5. Confirm the generated zip uses the `webmastery-site-toolkit-for-mcp` directory slug.
 6. Run the official WordPress Plugin Check utility against the generated `webmastery-site-toolkit-for-mcp` package and confirm there are no unexpected errors.
 7. Review the latest scheduled/manual `6 - Compatibility QA` result for upstream WordPress/PHP/plugin dependency drift.
-8. Tag and push `vX.Y.Z` to trigger the release workflow.
+8. Confirm the protected `wordpress-org` GitHub Environment and `SVN_USERNAME` / `SVN_PASSWORD` GitHub Actions secrets are configured.
+9. Tag and push `vX.Y.Z` to trigger the release workflow.
+10. Approve the protected WordPress.org deployment after release QA passes.
 
 ---
 
@@ -233,9 +237,10 @@ See [`docs/release-strategy.md`](docs/release-strategy.md) for the complete rele
 3. Add release notes to `readme.txt` under `== Changelog ==` and `== Upgrade Notice ==`
 4. Commit: `git commit -m "chore: release v1.x.x"`
 5. Tag and push: `git tag v1.x.x && git push origin v1.x.x`
-6. GitHub Actions runs contract, transport, package, and Plugin Check validation, then creates the release automatically
-7. Download the zip from the release and verify Plugin Check evaluates it as the `webmastery-site-toolkit-for-mcp` slug
-8. Upload the verified package to the WordPress.org SVN
+6. GitHub Actions runs contract, transport, package, and Plugin Check validation
+7. Approve the protected `wordpress-org` environment when the validated tag should publish to WordPress.org
+8. GitHub Actions deploys the curated build directory to WordPress.org SVN and creates the GitHub Release automatically
+9. Verify the WordPress.org Plugin Directory page updates as expected
 
 ### Plugin Check notes
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ For release history, see [CHANGELOG.md](CHANGELOG.md).
 
 ## Quickstart
 
-1. Install and activate the [MCP Adapter](https://github.com/WordPress/mcp-adapter) plugin.
-2. Install and activate **Webmastery Site Toolkit for MCP** from the [latest GitHub release](https://github.com/DanielBoring/webmastery-site-toolkit-for-mcp/releases/latest).
+1. Install and activate the [MCP Adapter](https://wordpress.org/plugins/mcp-adapter/) plugin.
+2. Install and activate **Webmastery Site Toolkit for MCP** from the WordPress.org Plugin Directory or the [latest GitHub release](https://github.com/DanielBoring/webmastery-site-toolkit-for-mcp/releases/latest).
 3. Create a dedicated WordPress user for the agent. Use **Editor** for normal content work.
 4. Create an application password for that user.
 5. Configure your MCP client with `@automattic/mcp-wordpress-remote`.
@@ -83,14 +83,17 @@ Self-hosted WordPress is required. This works on WordPress installs where custom
 
 ## Install
 
-Install the MCP Adapter first, then install this plugin.
+Install the MCP Adapter first, then install this plugin from **WP Admin > Plugins > Add New** by searching for **Webmastery Site Toolkit for MCP**.
+
+If you need to install a GitHub release ZIP manually, download the latest release package and upload it in **WP Admin > Plugins > Add New > Upload Plugin**.
+
+For local development, clone the repository into your WordPress plugins directory:
 
 ```bash
 git clone https://github.com/DanielBoring/webmastery-site-toolkit-for-mcp.git webmastery-site-toolkit-for-mcp
-zip -r webmastery-site-toolkit-for-mcp.zip webmastery-site-toolkit-for-mcp --exclude='webmastery-site-toolkit-for-mcp/.git/*'
 ```
 
-Upload `webmastery-site-toolkit-for-mcp.zip` in **WP Admin > Plugins > Add New > Upload Plugin**, then activate it.
+Then activate **Webmastery Site Toolkit for MCP** from the WordPress Plugins screen.
 
 ## Connect Your MCP Client
 

--- a/docs/ci-cd-strategy.md
+++ b/docs/ci-cd-strategy.md
@@ -18,7 +18,7 @@ This repository uses GitHub Actions as the automation layer for pull request che
 | `2 - Unit Tests` | `pull_request`, `push`, `workflow_dispatch` | Fast PHPUnit helper tests. |
 | `3-4 - Docker QA` | `pull_request`, `push`, `workflow_dispatch` | Runtime-impact detection, Ability Contract QA, Full MCP E2E QA, failure artifacts, and PR comment summaries. |
 | `5 - Release Package QA` | release-impacting `pull_request`, `workflow_dispatch` | Contract + transport Docker QA, package validation, and WordPress Plugin Check without publishing. |
-| `5 - Release` | tag push `v*` | Validates release inputs, runs Release Package QA, and publishes the GitHub release. |
+| `5 - Release` | tag push `v*` | Validates release inputs, runs Release Package QA, waits for protected WordPress.org approval, deploys to SVN, and publishes the GitHub release. |
 | `6 - Compatibility QA` | weekly `schedule`, `workflow_dispatch` | Runs Docker QA against primary and floating-latest WordPress/PHP stacks. |
 
 ## Pull request policy
@@ -58,8 +58,22 @@ Use least privilege per job:
 
 - Read-only jobs use `contents: read`.
 - PR comment jobs use `pull-requests: write` and avoid checking out PR-controlled code.
-- Release publishing uses `contents: write` only in the tag release workflow.
-- Secrets should not be needed for PR validation from forks. If future workflows require secrets, use environments and reviewer gates.
+- Release publishing uses `contents: write` only in the protected publish job of the tag release workflow.
+- Secrets should not be needed for PR validation from forks.
+- WordPress.org SVN credentials are GitHub Actions secrets named `SVN_USERNAME` and `SVN_PASSWORD`. Prefer storing them as `wordpress-org` environment secrets so they are unavailable until the protected environment is approved. Repository-level GitHub Secrets can work as a fallback, but the deploy job should still use the protected environment gate.
+
+## Environment gates
+
+The `wordpress-org` GitHub Environment protects the production SVN publish step. Release QA runs before the workflow reaches that environment, so normal validation does not need SVN credentials.
+
+Recommended `wordpress-org` environment settings:
+
+1. Require manual approval before deployment.
+2. Restrict secrets to the environment when possible.
+3. Store the WordPress.org SVN-specific password, not the normal account password.
+4. Treat approval as confirmation that the validated tag should publish to WordPress.org production SVN.
+
+There is no separate WordPress.org test SVN. Use pull request checks, `5 - Release Package QA`, manual compatibility checks, and staging WordPress installs for pre-production confidence.
 
 ## Scheduling policy
 
@@ -92,7 +106,7 @@ PR comments should summarize runtime facts rather than static success claims:
 1. Fix `1 - Static QA` failures first; they are usually syntax, standards, static-analysis, security-policy, dependency, manifest, or whitespace issues.
 2. Fix `2 - Unit Tests` before Docker failures; unit failures often indicate helper contract drift.
 3. For Docker failures, inspect the PR comment and uploaded artifacts.
-4. For release failures, distinguish package metadata/content failures from Plugin Check failures.
+4. For release failures, distinguish package metadata/content failures, Plugin Check failures, protected environment approval issues, SVN deployment failures, and GitHub Release creation failures.
 5. For scheduled compatibility failures, reproduce manually before changing required branch protection.
 
 ## Official references

--- a/docs/qa-strategy.md
+++ b/docs/qa-strategy.md
@@ -18,7 +18,7 @@ Related strategy guides:
 | 2 - Unit Tests | `composer qa:unit` | Small pieces of PHP logic behave correctly without booting WordPress. These tests are the fast safety net for sanitization, response shape, permission helpers, SEO metadata normalization, taxonomy helpers, plugin safety logic, and failure paths. | Every PR and every push to `main`. |
 | 3 - Ability Contract QA | `composer qa:contract` or `bash scripts/e2e-test.sh contract` | WordPress boots in Docker, required plugins load, every registered ability is represented in `tests/e2e/abilities-manifest.json`, manifest cases execute through `wp_get_ability()->execute()`, permission-sensitive cases pass, and the debug log stays clean. | Runtime PRs, ability PRs, security-sensitive PRs, `main`, releases, and manual dispatch. |
 | 4 - Full MCP E2E QA | `composer qa:e2e` or `bash scripts/e2e-test.sh e2e` | A real MCP HTTP JSON-RPC session can discover and execute abilities through the MCP Adapter, including Application Password authentication, session setup, tool discovery, editor CRUD, and subscriber denial. | Runtime PRs, ability PRs, security-sensitive PRs, `main`, releases, and manual dispatch. |
-| 5 - Release Package QA | `composer qa:release` or `bash scripts/release-qa.sh` | Release metadata is aligned, Ability Contract QA and Full MCP E2E QA pass, the release zip contains only packaged plugin files, and WordPress Plugin Check evaluates the built package instead of the development checkout. | Release PRs, tags, and manual dispatch. |
+| 5 - Release Package QA | `composer qa:release` or `bash scripts/release-qa.sh` | Release metadata is aligned, Ability Contract QA and Full MCP E2E QA pass, the release zip contains only packaged plugin files, and WordPress Plugin Check evaluates the built package instead of the development checkout. This check must pass before the protected WordPress.org SVN deploy job can run. | Release PRs, tags, and manual dispatch. |
 | 6 - Compatibility QA | `.github/workflows/compatibility-qa.yml` | Scheduled/manual Docker QA against the primary stack and a floating-latest PHP/WordPress image catches upstream drift in WordPress, PHP, MCP Adapter, Yoast SEO, SEOPress, and Plugin Check dependencies. | Weekly schedule, manual dispatch, release-candidate investigation, and upstream-breakage triage. |
 
 ## Security QA policy
@@ -164,7 +164,7 @@ Before publishing a WordPress.org-facing release:
 4. Confirm no unexpected WordPress debug-log warnings, notices, deprecations, or errors appear during Docker QA.
 5. Confirm security-sensitive changes have manifest evidence for allowed and denied access.
 6. Review the official [WordPress.org Detailed Plugin Guidelines](https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/) for release-impacting changes, especially licensing, bundled assets, external services, tracking consent, executable remote code, readme content, default WordPress libraries, SVN discipline, version increments, and trademarks.
-7. Run or review the latest `6 - Compatibility QA` result before uploading a release candidate to WordPress.org.
+7. Run or review the latest `6 - Compatibility QA` result before approving WordPress.org SVN deployment.
 8. Document any known Plugin Check warnings, guideline considerations, or unavailable local tooling in the PR.
 
 Plugin Check supports the guideline review, but it does not replace maintainer responsibility for the final WordPress.org package contents and behavior.

--- a/docs/release-strategy.md
+++ b/docs/release-strategy.md
@@ -21,6 +21,21 @@ This project uses semantic versioning:
 
 Security fixes can be patch releases when the public API remains compatible.
 
+GitHub release tags use `vX.Y.Z`. WordPress.org SVN release tags use `X.Y.Z` because WordPress.org recommends numeric Subversion tag names containing only numbers and periods. Every user-facing code release, including patch releases, should be eligible for WordPress.org SVN deployment after release QA passes.
+
+Readme-only or Plugin Directory asset-only updates do not require a plugin version bump when they are cosmetic and do not ship code changes. Avoid using SVN commits as routine documentation churn; WordPress.org treats SVN as a release repository.
+
+## Release cadence
+
+Releases are readiness-based, not calendar-based:
+
+| Release need | Policy |
+| --- | --- |
+| Security fix or serious user-impacting bug | Publish a patch release as soon as the fix passes release QA. |
+| Normal bug fixes or backward-compatible features | Batch into intentional patch or minor releases when there is user-facing value. |
+| Compatibility/readme-only update | Publish only when needed; do not force a code release for cosmetic readme or listing asset changes. |
+| Internal repository, CI, or contributor workflow changes | Do not publish a plugin release unless packaged plugin behavior or user-facing documentation changes. |
+
 ## Release readiness checklist
 
 Before tagging a release:
@@ -35,15 +50,18 @@ Before tagging a release:
 8. Run or confirm `composer qa:release`.
 9. Review the latest `6 - Compatibility QA` result for upstream drift.
 10. Confirm no unexpected Plugin Check findings remain.
+11. Confirm the `wordpress-org` GitHub Environment approval gate and SVN secrets are configured before pushing a release tag that should publish to WordPress.org.
 
-## GitHub release flow
+## Tag release flow
 
-The tag workflow owns GitHub release creation:
+The tag workflow owns release validation, WordPress.org SVN deployment, and GitHub release creation:
 
 1. Maintainer pushes `vX.Y.Z`.
 2. `.github/workflows/release.yml` validates the tag, plugin header, stable tag, text domain, short description, release notes, and duplicate release state.
 3. `scripts/release-qa.sh` runs Ability Contract QA and Full MCP E2E QA, builds the release zip, validates package contents, and runs WordPress Plugin Check.
-4. GitHub release is created with the built zip and notes from `readme.txt`.
+4. The workflow waits for approval in the protected `wordpress-org` GitHub Environment.
+5. After approval, the workflow deploys the validated plugin code to WordPress.org SVN.
+6. GitHub release is created with the built zip and notes from `readme.txt`.
 
 Do not manually upload an unvalidated zip to GitHub releases.
 
@@ -51,16 +69,36 @@ Do not manually upload an unvalidated zip to GitHub releases.
 
 WordPress.org uses SVN as the release repository. GitHub remains the development repository.
 
-Recommended process:
+Automated process:
 
-1. Download the GitHub release zip after the tag workflow passes.
-2. Inspect or extract the package if needed.
-3. Commit finished release files to WordPress.org SVN `trunk`.
-4. Copy or tag the release to the matching SVN `tags/X.Y.Z` path.
-5. Confirm `Stable tag` points to the intended release.
-6. Verify the WordPress.org plugin page updates as expected.
+1. The release workflow builds the curated package directory at `build/webmastery-site-toolkit-for-mcp`.
+2. The protected `wordpress-org` environment gates access to the real SVN publish step.
+3. `10up/action-wordpress-plugin-deploy` deploys the contents of `build/webmastery-site-toolkit-for-mcp` to SVN `trunk`.
+4. The deploy action copies `trunk` to the matching SVN `tags/X.Y.Z` path.
+5. The workflow creates the GitHub Release after SVN deployment succeeds.
+6. Maintainers verify the WordPress.org plugin page updates as expected.
 
 Avoid frequent small SVN commits. WordPress.org guidance treats SVN as a release repository, not the day-to-day development repository.
+
+WordPress.org SVN is production. There is no separate WordPress.org test SVN for this plugin. Use pull request QA, `5 - Release Package QA`, optional manual compatibility checks, staging WordPress installs, and the protected environment approval gate before publishing.
+
+### GitHub environment and secrets
+
+Use a protected GitHub Environment named `wordpress-org` for real SVN publishing.
+
+Recommended settings:
+
+1. Require manual approval before jobs in the environment run.
+2. Add GitHub Actions secrets named `SVN_USERNAME` and `SVN_PASSWORD`.
+3. Prefer environment-scoped secrets on `wordpress-org` so credentials are only available after approval.
+4. Use repository-level GitHub Secrets only if environment secrets are not available; keep the deploy job behind environment approval either way.
+5. Use the WordPress.org SVN-specific password, not the normal WordPress.org account password.
+
+### Partial failure recovery
+
+The workflow deploys to WordPress.org SVN before creating the GitHub Release so WordPress.org is updated before GitHub advertises the release. If SVN deployment succeeds but GitHub Release creation fails, do not re-tag or rewrite history. Re-run the failed workflow job if possible, or manually create the GitHub Release from the existing trusted tag and validated release notes.
+
+If GitHub Release creation somehow succeeds while WordPress.org deployment does not, treat the release as partially published: fix the SVN deployment issue, re-run the protected publish job when safe, or publish a follow-up patch release if the failed state could affect users.
 
 ## WordPress.org guideline governance
 

--- a/docs/security-strategy.md
+++ b/docs/security-strategy.md
@@ -67,7 +67,7 @@ Current runtime enforcement:
 - Prefer GitHub Actions `GITHUB_TOKEN` with explicit job-level `permissions`.
 - Do not expose secrets to workflows running untrusted PR code.
 - Rotate any secret that appears in logs or repository history.
-- Keep release credentials outside repository files; use GitHub secrets/environments if future automation requires them.
+- Keep release credentials outside repository files. WordPress.org SVN deployment uses GitHub Actions secrets named `SVN_USERNAME` and `SVN_PASSWORD`; prefer storing them as protected `wordpress-org` environment secrets so they are only available after approval. Repository-level GitHub Secrets can work as a fallback, but the publish job must remain protected by the environment gate.
 
 ## WordPress.org guideline security and privacy expectations
 

--- a/readme.txt
+++ b/readme.txt
@@ -39,7 +39,7 @@ https://www.virtuallyboring.com/webmastery-site-toolkit-for-mcp/
 == Installation ==
 
 1. Install and activate the [MCP Adapter](https://wordpress.org/plugins/mcp-adapter/) plugin first.
-2. Upload the `webmastery-site-toolkit-for-mcp` folder to `/wp-content/plugins/`, or install the plugin zip from **Plugins > Add New > Upload Plugin**.
+2. Install **Webmastery Site Toolkit for MCP** from **Plugins > Add New** by searching for the plugin name, or upload the plugin zip from **Plugins > Add New > Upload Plugin**.
 3. Activate **Webmastery Site Toolkit for MCP** from the WordPress Plugins screen.
 4. Create a dedicated WordPress user for your MCP client. Use Editor for day-to-day content work.
 5. Create an application password for that user from the WordPress user profile screen.


### PR DESCRIPTION
## Summary
- Split tag-based release workflow into validation and protected publish jobs
- Deploy validated release build output to WordPress.org SVN using a pinned 10up deploy action
- Document SemVer/SVN tag policy, protected `wordpress-org` approval, GitHub Actions SVN secrets, release cadence, and partial-failure recovery
- Update contributor, PR, automation, security, QA, README, and WordPress.org readme guidance

## Testing
- `composer qa`
- `composer qa:release`
- `git diff --check`

## Follow-up outside the repo
- Configure the protected `wordpress-org` GitHub Environment
- Add `SVN_USERNAME` and `SVN_PASSWORD` as GitHub Actions secrets, preferably environment-scoped